### PR TITLE
Add a hint about running manage.py on deployments

### DIFF
--- a/website/server/docs/deploying.md
+++ b/website/server/docs/deploying.md
@@ -62,6 +62,14 @@ to the running instance.
 > **Note**: There are a few quirks with the SSH session. You'll likely need to manually
 > activate the virtualenv and `cd` into the `WORKDIR` of your Docker image.
 
+### Invoking manage.py commands
+
+Note that the default Dockerfile deletes the default settings module and replaces it with
+an environment variable. So to run a manage.py command (for example, createsuperuser) on
+the fly.io app instance, you can set the correct environment via:
+
+    DJANGO_SETTINGS_MODULE=server.settings.production ./manage.py
+
 ## Custom domain
 
 Adding a custom domain with **TLS** is easy. However, we don't automate the process


### PR DESCRIPTION
Got bit by this on my first deploy and had to trace back to find the root cause.  Adding this so hopefully the next user wont.

Let me know if you have any feedback on the wording