### PR TITLE
Add support for Django-CSP

### DIFF
--- a/packages/reactivated/src/renderer.tsx
+++ b/packages/reactivated/src/renderer.tsx
@@ -30,12 +30,15 @@ export const renderPage = ({
     helmet: HelmetServerState;
     context: any;
     props: any;
-}) =>
-    `
+}) => {
+    const scriptNonce = context.request.csp_nonce
+        ? `nonce="${context.request.csp_nonce}"`
+        : "";
+    return `
 <!DOCTYPE html>
 <html ${helmet.htmlAttributes.toString()}>
     <head>
-        <script>
+        <script ${scriptNonce}>
             // These go first because scripts below need them.
             // WARNING: See the following for security issues around embedding JSON in HTML:
             // http://redux.js.org/recipes/ServerRendering.html#security-considerations
@@ -60,8 +63,8 @@ export const renderPage = ({
     <body ${helmet.bodyAttributes.toString()}>
         <div id="root">${html}</div>
     </body>
-</html>
-`;
+</html>`;
+};
 
 const PATHS = ["/", "/form/"];
 

--- a/reactivated/serialization/context_processors.py
+++ b/reactivated/serialization/context_processors.py
@@ -1,12 +1,4 @@
-from typing import (
-    Any,
-    List,
-    Literal,
-    NamedTuple,
-    Optional,
-    Type,
-    get_type_hints,
-)
+from typing import Any, Dict, List, Literal, NamedTuple, Optional, Type, get_type_hints
 
 from django.http import HttpRequest
 from django.utils.module_loading import import_string
@@ -24,16 +16,14 @@ class Request(NamedTuple):
     def get_serialized_value(
         Type: Type["Request"], value: HttpRequest, schema: Thing
     ) -> JSON:
-        serialized = {
+        serialized: Dict[str, Optional[str]] = {
             "path": value.path,
             "url": value.build_absolute_uri(),
         }
         # If django-csp is in use, include the CSP nonce for the request
         # See https://django-csp.readthedocs.io/en/latest/nonce.html#using-the-generated-csp-nonce
         serialized["csp_nonce"] = (
-            str(value.csp_nonce)
-            if hasattr(value, "csp_nonce")
-            else None
+            str(value.csp_nonce) if hasattr(value, "csp_nonce") else None  # type: ignore[attr-defined]
         )
         return serialized
 

--- a/reactivated/serialization/context_processors.py
+++ b/reactivated/serialization/context_processors.py
@@ -1,31 +1,30 @@
-from typing import Any, Dict, List, Literal, NamedTuple, Optional, Type, get_type_hints
+from typing import Any, List, Literal, NamedTuple, Optional, Type, get_type_hints
 
 from django.http import HttpRequest
 from django.utils.module_loading import import_string
 
-from . import Intersection
+from . import Intersection, serialize
 from .registry import JSON, Thing
 
 
 class Request(NamedTuple):
     path: str
     url: str
+
+    # If django-csp is in use, include the CSP nonce for the request
+    # See https://django-csp.readthedocs.io/en/latest/nonce.html#using-the-generated-csp-nonce
     csp_nonce: Optional[str]
 
     @classmethod
     def get_serialized_value(
         Type: Type["Request"], value: HttpRequest, schema: Thing
     ) -> JSON:
-        serialized: Dict[str, Optional[str]] = {
-            "path": value.path,
+        serialized = serialize(value, schema, suppress_custom_serializer=True)
+
+        return {
+            **serialized,
             "url": value.build_absolute_uri(),
         }
-        # If django-csp is in use, include the CSP nonce for the request
-        # See https://django-csp.readthedocs.io/en/latest/nonce.html#using-the-generated-csp-nonce
-        serialized["csp_nonce"] = (
-            str(value.csp_nonce) if hasattr(value, "csp_nonce") else None  # type: ignore[attr-defined]
-        )
-        return serialized
 
 
 class RequestProcessor(NamedTuple):

--- a/tests/templates.py
+++ b/tests/templates.py
@@ -85,8 +85,21 @@ def test_render_template_with_no_renderer(rf, settings):
         "context": {
             "template_name": "MyTemplate",
             "messages": [],
-            "request": {"path": "/", "url": "http://testserver/"},
+            "request": {"path": "/", "url": "http://testserver/", "csp_nonce": None},
             "csrf_token": "CLOBBERED",
         },
         "props": {"foo": 1.0},
     }
+
+
+def test_csp_nonce(rf, settings):
+    settings.REACTIVATED_SERVER = None
+    request = rf.get("/")
+    request.csp_nonce = 567  # To ensure casting is working
+
+    @template
+    class MyTemplate(NamedTuple):
+        foo: int
+
+    rendered = simplejson.loads(MyTemplate(foo=1).render(request).rendered_content)
+    assert rendered["context"]["request"]["csp_nonce"] == "567"

--- a/tests/types.py
+++ b/tests/types.py
@@ -577,8 +577,12 @@ def test_context_processor_type():
             "serializer": "reactivated.serialization.context_processors.Request",
             "type": "object",
             "additionalProperties": False,
-            "properties": {"path": {"type": "string"}, "url": {"type": "string"}},
-            "required": ["path", "url"],
+            "properties": {
+                "path": {"type": "string"},
+                "url": {"type": "string"},
+                "csp_nonce": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            },
+            "required": ["path", "url", "csp_nonce"],
         },
         "reactivated.serialization.context_processors.RequestProcessor": {
             "serializer": None,


### PR DESCRIPTION
If the django-csp is installed and in-use, this changes automatically includes the CSP nonce in the inline script that reactivated begins each page with. This allows reactivate-based sites to use CSP headers without having to enable `script-src: 'unsafe-inline'`.