### PR TITLE
Provide hooks to allow customizing ESBuild config

### DIFF
--- a/packages/reactivated/src/build.client.mts
+++ b/packages/reactivated/src/build.client.mts
@@ -4,6 +4,8 @@ import linaria from "./linaria.mjs";
 import {vanillaExtractPlugin} from "@vanilla-extract/esbuild-plugin";
 import * as esbuild from "esbuild";
 import ImportGlobPlugin from "esbuild-plugin-import-glob";
+import produce from "immer";
+import {loadConfig} from "./config";
 
 const entryNames = process.argv.slice(2);
 
@@ -20,57 +22,59 @@ const env = {
     TAG_VERSION: process.env.TAG_VERSION,
 };
 
-esbuild
-    .context({
-        entryPoints,
-        bundle: true,
-        // We use terser to minify because esbuild breaks safari sourcemaps.
-        // It's likely a Safari bug, but terser seems to work for some reason.
-        minify: false,
-        // Related to sourcemaps as well in Safari.
-        legalComments: "none",
-        platform: "browser",
-        outdir: "./static/dist",
-        sourcemap: true,
-        target: "es2018",
-        preserveSymlinks: true,
-        external: ["moment", "@client/generated/images"],
-        define: {
-            // You need both. The one from the stringified JSON is not picked
-            // up during the build process.
-            "process.env.NODE_ENV": production ? '"production"' : '"development"',
-            process: JSON.stringify({env}),
+const defaultConfig: Readonly<esbuild.BuildOptions> = {
+    entryPoints,
+    bundle: true,
+    // We use terser to minify because esbuild breaks safari sourcemaps.
+    // It's likely a Safari bug, but terser seems to work for some reason.
+    minify: false,
+    // Related to sourcemaps as well in Safari.
+    legalComments: "none",
+    platform: "browser",
+    outdir: "./static/dist",
+    sourcemap: true,
+    target: "es2018",
+    preserveSymlinks: true,
+    external: ["moment", "@client/generated/images"],
+    define: {
+        // You need both. The one from the stringified JSON is not picked
+        // up during the build process.
+        "process.env.NODE_ENV": production ? '"production"' : '"development"',
+        process: JSON.stringify({env}),
 
-            // Redux persist needs this.
-            global: "{}",
-        },
-        loader: {
-            ".gif": "file",
-            ".jpeg": "file",
-            ".jpg": "file",
-            ".png": "file",
-            ".svg": "file",
-            ".ttf": "file",
-            ".woff": "file",
-            ".woff2": "file",
-        },
-        plugins: [
-            // ESM imports make this weird.
-            (ImportGlobPlugin as unknown as {default: () => esbuild.Plugin}).default(),
-            // We manually pass in identifiers because the client is not
-            // minified by esbuild but the renderer is, so class names could
-            // differ.
-            // Instead of set it manually instead of relying on minification
-            // settings.
-            vanillaExtractPlugin({identifiers}),
-            linaria({sourceMap: true, esbuildOptions: {sourcemap: "inline"}}),
-        ],
-    })
-    .then(async (context) => {
-        if (production === false) {
-            context.watch();
-        } else {
-            await context.rebuild();
-            process.exit();
-        }
-    });
+        // Redux persist needs this.
+        global: "{}",
+    },
+    loader: {
+        ".gif": "file",
+        ".jpeg": "file",
+        ".jpg": "file",
+        ".png": "file",
+        ".svg": "file",
+        ".ttf": "file",
+        ".woff": "file",
+        ".woff2": "file",
+    },
+    plugins: [
+        // ESM imports make this weird.
+        (ImportGlobPlugin as unknown as {default: () => esbuild.Plugin}).default(),
+        // We manually pass in identifiers because the client is not
+        // minified by esbuild but the renderer is, so class names could
+        // differ.
+        // Instead of set it manually instead of relying on minification
+        // settings.
+        vanillaExtractPlugin({identifiers}),
+        linaria({sourceMap: true, esbuildOptions: {sourcemap: "inline"}}),
+    ],
+};
+
+const finalConfig = produce(defaultConfig, loadConfig().clientBuildConfig);
+
+esbuild.context(finalConfig).then(async (context) => {
+    if (production === false) {
+        context.watch();
+    } else {
+        await context.rebuild();
+        process.exit();
+    }
+});

--- a/packages/reactivated/src/config.tsx
+++ b/packages/reactivated/src/config.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import {BuildOptions} from "esbuild";
+
+export type Config = Readonly<{
+    clientBuildConfig: (options: BuildOptions) => BuildOptions;
+    rendererBuildConfig: (options: BuildOptions) => BuildOptions;
+    renderPage: (template: React.ReactNode) => React.ReactNode;
+}>;
+
+const ident = <T,>(x: T) => x;
+const defaults: Config = {
+    clientBuildConfig: ident,
+    rendererBuildConfig: ident,
+    renderPage: ident,
+};
+
+/**
+ * Function exists mainly just for type checking
+ */
+export const config = (c: Partial<Config>): Partial<Config> => {
+    return c;
+};
+
+/**
+ * Load the project custom configuration
+ */
+export const loadConfig = (): Config => {
+    let overrides: Partial<Config> = {};
+    try {
+        overrides = require(`${process.cwd()}/client/reactivated.conf`).default;
+    } catch (e) {
+        console.debug(`Could not load @client/reactivated.conf: ${e}`);
+    }
+    return {
+        ...defaults,
+        ...overrides,
+    };
+};

--- a/packages/reactivated/src/index.tsx
+++ b/packages/reactivated/src/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
 
+export * from "./config";
 export * from "./components/Form";
 export * from "./components/Widget";

--- a/packages/reactivated/src/renderer.tsx
+++ b/packages/reactivated/src/renderer.tsx
@@ -12,6 +12,9 @@ import {
 } from "react-helmet-async";
 
 import {Settings} from "./models";
+import {loadConfig} from "./config";
+
+const config = loadConfig();
 
 // TODO: WHAT DOES THIS NEED TO BE? Even 100k was super fragile and a 10 choice field broke it.
 export const BODY_SIZE_LIMIT = "100000000k";
@@ -91,7 +94,7 @@ export const render = async ({
         const rendered = ReactDOMServer.renderToString(
             <HelmetProvider context={helmetContext}>
                 <Provider value={context}>
-                    <Template {...props} />
+                    {config.renderPage(<Template {...props} />)}
                 </Provider>
             </HelmetProvider>,
         );

--- a/reactivated/__init__.py
+++ b/reactivated/__init__.py
@@ -208,7 +208,6 @@ class TypeHint(abc.ABC):
 
 
 def create_schema(Type: Any, definitions: Dict[Any, Any], ref: bool = True) -> Any:
-
     if isinstance(Type, _GenericAlias):
         if Type.__origin__ == tuple:
             *tuple_args, last_arg = Type.__args__
@@ -268,7 +267,6 @@ def create_schema(Type: Any, definitions: Dict[Any, Any], ref: bool = True) -> A
                 field_schema = create_schema(SubType, definitions, ref=ref)
 
                 if field_schema is not None:
-
                     required.append(field_name)
                     properties[field_name] = field_schema
 

--- a/reactivated/apps.py
+++ b/reactivated/apps.py
@@ -171,6 +171,7 @@ class ReactivatedConfig(AppConfig):
 
             schema = get_schema()
             generate_schema(schema)
+            processes.start_config_build()
             processes.start_tsc()
             processes.start_client()
             processes.start_renderer()

--- a/reactivated/config.py
+++ b/reactivated/config.py
@@ -1,0 +1,46 @@
+import subprocess
+import os
+from pathlib import Path
+from typing import Optional
+from django.conf import settings
+
+
+client_path = Path(settings.BASE_DIR).joinpath("client/")
+client_config_src_path = client_path.joinpath("reactivated.conf.tsx")
+
+
+def build_client_config(watch=False, **kwargs) -> Optional[subprocess.Popen]:
+    if not client_config_src_path.exists():
+        return
+    config = {
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "jsx": "react",
+        "target": "es2021",
+        "esModuleInterop": True,
+        "outDir": client_path,
+    }
+    if watch:
+        config["watch"] = True
+        config["preserveWatchOutput"] = True
+
+    args = []
+    for flag, value in config.items():
+        args.append(f"--{flag}")
+        if value and value is not True:
+            args.append(value)
+
+    tsc_process = subprocess.Popen(
+        [
+            "npm",
+            "exec",
+            "tsc",
+            "--",
+            *args,
+            client_config_src_path,
+        ],
+        env={**os.environ.copy()},
+        cwd=settings.BASE_DIR,
+        **kwargs,
+    )
+    return tsc_process

--- a/reactivated/management/commands/build.py
+++ b/reactivated/management/commands/build.py
@@ -5,6 +5,8 @@ from typing import Any
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+from ...config import build_client_config, client_config_src_path
+
 DIST_ROOT = "static/dist/"
 
 
@@ -30,6 +32,14 @@ class Command(BaseCommand):
             **os.environ.copy(),
             "NODE_ENV": "production",
         }
+
+        client_config_process = build_client_config(stdout=subprocess.PIPE)
+        if client_config_process is not None:
+            client_config_process.communicate()
+            if client_config_process.returncode != 0:
+                raise CommandError(
+                    f"TypeScript error. Failed to compile {client_config_src_path}"
+                )
 
         tsc_process = subprocess.Popen(
             ["npm", "exec", "tsc", "--", "--noEmit"],


### PR DESCRIPTION
This change provides hooks to allow users of the library to customize the projects ESBuild configuration. 

For example, assume that a reactivated-based site wanted to use CSS modules. Even though reactivated itself doesn't support this, once this is merged, a site could add config tweak files like this, correlating to [packages/reactivated/src/build.client.tsx](packages/reactivated/src/build.client.tsx) and [packages/reactivated/src/build.renderer.tsx](packages/reactivated/src/build.renderer.tsx), respectively.

```ts
# > client/.reactivated/build.client.ts
import { BuildOptions } from "esbuild";

const classModules = require("esbuild-plugin-class-modules");

export const getBuildConfig = (config: BuildOptions): BuildOptions => {
    config.plugins = config.plugins || [];
    config.plugins.push(classModules());
    return config;
};
```

```ts
# > client/.reactivated/build.renderer.ts
import { BuildOptions } from "esbuild";

const classModules = require("esbuild-plugin-class-modules");

export const getBuildConfig = (config: BuildOptions): BuildOptions => {
    config.plugins = config.plugins || [];
    config.plugins.push(classModules());
    return config;
};
```
