### PR TITLE
Fix Nix dependencies with Docker

### DIFF
--- a/development/shell.nix
+++ b/development/shell.nix
@@ -5,7 +5,8 @@ in with requirements.pkgs;
 mkShell {
   dependencies = requirements.production_dependencies;
   buildInputs = requirements.production_dependencies
-    ++ requirements.development_dependencies;
+    ++ requirements.development_dependencies
+    ++ requirements.contributing_dependencies;
   shellHook = ''
     setup_script="$(npm bin)/setup_environment.sh"
 

--- a/requirements.nix
+++ b/requirements.nix
@@ -35,7 +35,6 @@ in with pkgs; {
     pkgs.shellcheck
     pkgs.nixfmt
   ];
-  contributing_dependencies =
-    [ pkgs.gitAndTools.gh pkgs.ripgrep pkgs.nix pkgs.cacert pkgs.bash ];
+  contributing_dependencies = [ pkgs.gitAndTools.gh pkgs.ripgrep pkgs.bash ];
 
 }

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ in with requirements.pkgs;
 mkShell {
   buildInputs = requirements.production_dependencies
     ++ requirements.development_dependencies
-    ++ requirements.contributing_dependencies;
+    ++ requirements.contributing_dependencies ++ [ requirements.pkgs.nix ];
   shellHook = ''
     source "./packages/reactivated/scripts/setup_environment.sh"
   '';

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,11 @@ in with requirements.pkgs;
 mkShell {
   buildInputs = requirements.production_dependencies
     ++ requirements.development_dependencies
-    ++ requirements.contributing_dependencies ++ [ requirements.pkgs.nix ];
+    ++ requirements.contributing_dependencies ++ [
+      # Needed for recursive nix-shell --pure scripts
+      # Like scripts/script-create-django-app.sh calling sync-development.sh
+      requirements.pkgs.nix
+    ];
   shellHook = ''
     source "./packages/reactivated/scripts/setup_environment.sh"
   '';

--- a/website/shell.nix
+++ b/website/shell.nix
@@ -5,7 +5,8 @@ in with requirements.pkgs;
 mkShell {
   dependencies = requirements.production_dependencies;
   buildInputs = requirements.production_dependencies
-    ++ requirements.development_dependencies;
+    ++ requirements.development_dependencies
+    ++ requirements.contributing_dependencies;
   shellHook = ''
     source $(npm bin)/setup_environment.sh
   '';


### PR DESCRIPTION
Having pkgs.nix in contributing dependencies causes issues in the Dockerfile.

After this line:

`RUN nix-env -f shell.nix -i -A buildInputs`

The following line fails because `nix-env` is not found:

`RUN nix-env -f shell.nix -i -A dependencies --profile /output/profile`
