### PR TITLE
Add FloatField serialization

### DIFF
--- a/reactivated/serialization/__init__.py
+++ b/reactivated/serialization/__init__.py
@@ -541,6 +541,7 @@ register(models.PositiveIntegerField)(int)
 
 register(models.DecimalField)(str)
 
+register(models.FloatField)(float)
 
 @register(fields._EnumField)
 class EnumFieldType:

--- a/reactivated/serialization/__init__.py
+++ b/reactivated/serialization/__init__.py
@@ -543,6 +543,7 @@ register(models.DecimalField)(str)
 
 register(models.FloatField)(float)
 
+
 @register(fields._EnumField)
 class EnumFieldType:
     @classmethod


### PR DESCRIPTION
## Issue

Float field serialisation currently does now work. When using pick on a float backed Django field the serialisation fails with the following:

```
Traceback (most recent call last):
  File "/Users/leszek/Desktop/prompt_wiz/manage.py", line 22, in <module>
    main()
  File "/Users/leszek/Desktop/prompt_wiz/manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/django/core/management/__init__.py", line 425, in execute_from_command_line
    utility.execute()
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/django/core/management/__init__.py", line 419, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/django/core/management/base.py", line 373, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/django/core/management/commands/runserver.py", line 66, in execute
    super().execute(*args, **options)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/django/core/management/base.py", line 417, in execute
    output = self.handle(*args, **options)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/django/core/management/commands/runserver.py", line 101, in handle
    self.run(**options)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/django/core/management/commands/runserver.py", line 108, in run
    autoreload.run_with_reloader(self.inner_run, **options)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/django/utils/autoreload.py", line 646, in run_with_reloader
    exit_code = restart_with_reloader()
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/__init__.py", line 45, in patched_restart_with_reloader
    schema = get_schema()
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/apps.py", line 132, in get_schema
    "types": get_types_schema(),
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/apps.py", line 94, in get_types_schema
    parent_schema, definitions = create_schema(ParentTuple, definitions_registry)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/serialization/__init__.py", line 786, in create_schema
    return named_tuple_schema(Type, definitions)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/serialization/__init__.py", line 725, in named_tuple_schema
    field_schema = create_schema(Subtype, definitions)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/serialization/__init__.py", line 786, in create_schema
    return named_tuple_schema(Type, definitions)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/serialization/__init__.py", line 725, in named_tuple_schema
    field_schema = create_schema(Subtype, definitions)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/serialization/__init__.py", line 774, in create_schema
    return generic_alias_schema(Type, definitions)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/serialization/__init__.py", line 576, in generic_alias_schema
    subschema = create_schema(Type.__args__[0], definitions=definitions)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/serialization/__init__.py", line 780, in create_schema
    return Type.get_json_schema(definitions)  # type: ignore[no-any-return]
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/pick.py", line 293, in get_json_schema
    field_schema = create_schema(
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/serialization/__init__.py", line 776, in create_schema
    return field_descriptor_schema(Type, definitions)
  File "/Users/leszek/Desktop/prompt_wiz/.venv/lib/python3.9/site-packages/reactivated/serialization/__init__.py", line 523, in field_descriptor_schema
    assert (
AssertionError: Unsupported model field type <class 'django.db.models.fields.FloatField'>. This should probably silently return None and allow a custom handler to support the field.
```

After adding the support, it works again.