### PR TITLE
Fix import issues when using isolated modules mode

### DIFF
--- a/packages/reactivated/src/generator.mts
+++ b/packages/reactivated/src/generator.mts
@@ -280,7 +280,7 @@ sourceFile.addStatements(
 );
 
 sourceFile.addStatements(`
-export {Options} from "reactivated/dist/conf";
+export type {Options} from "reactivated/dist/conf";
 
 export const rpc = new RPC(typeof window != "undefined" ? rpcUtils.defaultRequester : null as any);
 import React from "react"
@@ -320,7 +320,7 @@ export const {createRenderer, Iterator} = forms.bindWidgetType<_Types["globals"]
 export type FieldHandler = forms.FieldHandler<_Types["globals"]["Widget"]>;
 export type models = _Types["globals"]["models"];
 
-export {FormHandler} from "reactivated/dist/forms";
+export type {FormHandler} from "reactivated/dist/forms";
 export const {Form, FormSet, Widget, useForm, useFormSet, ManagementForm} = forms;
 `);
 


### PR DESCRIPTION
Typescript's isolated modules mode[^1] and other tools that work like this, like Storybook w/ it's Vite builder, produce an "ambiguous import" error when they get to the `export ... from` lines in `@reactivated/index.tsx`. Changing these to `export type` doesn't alter the behavior, but does fix this error.

[^1]: https://www.typescriptlang.org/tsconfig#isolatedModules