### PR TITLE
Fix termination of React processes

### DIFF
--- a/reactivated/processes.py
+++ b/reactivated/processes.py
@@ -1,9 +1,25 @@
 import atexit
 import os
 import re
+import signal
 import subprocess
+from typing import Any
 
 from django.conf import settings
+
+
+def terminate_proc(proc: subprocess.Popen[Any]) -> None:
+    """
+    npm exec doesn't correctly forward signals to its child processes. So,
+    simply calling proc.terminate() doesn't actually kill the process. Rather,
+    we have to send SIGTERM to the entire process group.
+
+    Note: using this requires that the initial call to subprocess.Popen included
+    the `start_new_session=True` flag.
+    """
+    pgrp = os.getpgid(proc.pid)
+    os.killpg(pgrp, signal.SIGTERM)
+    proc.communicate(timeout=5)
 
 
 def start_tsc() -> None:
@@ -11,9 +27,10 @@ def start_tsc() -> None:
         ["npm", "exec", "tsc", "--", "--watch", "--noEmit", "--preserveWatchOutput"],
         # stdout=subprocess.PIPE,
         # stderr=subprocess.PIPE,
+        start_new_session=True,
         env={**os.environ.copy()},
     )
-    atexit.register(lambda: tsc_process.terminate())
+    atexit.register(lambda: terminate_proc(tsc_process))
 
 
 def start_client() -> None:
@@ -28,9 +45,10 @@ def start_client() -> None:
             *entry_points,
         ],
         stdout=subprocess.PIPE,
+        start_new_session=True,
         env={**os.environ.copy()},
     )
-    atexit.register(lambda: client_process.terminate())
+    atexit.register(lambda: terminate_proc(client_process))
 
 
 def start_renderer() -> None:
@@ -43,11 +61,12 @@ def start_renderer() -> None:
         ["npm", "exec", "build.renderer"],
         encoding="utf-8",
         stdout=subprocess.PIPE,
+        start_new_session=True,
         env={
             **os.environ.copy(),
         },
     )
-    atexit.register(lambda: renderer_process.terminate())
+    atexit.register(lambda: terminate_proc(renderer_process))
 
     renderer_process_port = ""
     output = ""


### PR DESCRIPTION
Extracted from #322 since this bug isn't unique to that branch, it exists in main as well.

When the dev server restarts, it successfully terminates the npm exec process. But, the child esbuild processes don't terminate as expected. Thus, after a short development period, quite a number of esbuild processes can pile up on the system.

This changes fixes the issue by starting each process in a new process group. Then, instead of terminating the npm process itself, we terminate the entire process group. This logic is based on the solution described here: https://stackoverflow.com/a/32222971/162220