### PR TITLE
Fix nested tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ jobs:
               with:
                   fetch-depth: 0
             - uses: ./.github/actions/setup
+            - name: Post setup
+              uses: mxschmitt/action-tmate@v3
             - name: Run tests
               run: nix-shell --command "scripts/test.sh"
             - name: Setup tmate session


### PR DESCRIPTION
Someone `sample` ends up inside `site-packages` sometimes when restoring from cache. not sure why.