### PR TITLE
Fix multiprocess port conflicts

### DIFF
--- a/packages/create-django-app/Dockerfile
+++ b/packages/create-django-app/Dockerfile
@@ -10,7 +10,6 @@ ENV USER=guest
 RUN curl -L https://nixos.org/nix/install | sh
 
 ENV PATH="/home/guest/.nix-profile/bin:/reactivated/scripts/:${PATH}"
-ENV REACTIVATED_SOCKET=/tmp/reactivated.sock
 ENV TMPDIR=/tmp
 
 COPY --chown=guest package.json /reactivated/package.json


### PR DESCRIPTION
In `renderer.py:wait_and_get_port`, the `renderer_process_port` global is used to prevent starting multiple SSR servers. This does not work as intended in prod environments (in our case, uwsgi with 8-16 worker processes). Here's what I've observed:

1. uwsgi (or any multi-process server) starts.
2. If the first request handled by the server is a template-render, and thus causes the SSR render server to start, that request and all subsequent requests handled by the server will be fine. 
3. If the first request handled by the server does not start the SSR server (e.g. it's an API request), the server will for the rest of it's life throw timeouts and log this error: `Error: listen EADDRINUSE: address already in use :::5173`.

Based on the code, I think this is due to (1) the `renderer_process_port` global and (2) how copy-on-write works when forking multiple processes. 

1. In the first case when the first request starts the SSR server, the `renderer_process_port` global is set and copy-on-write causes all the other processes to inherit that initial value. So that server will work fine because all the worker processes know that the SSR server is running and on what port.
2. But, in the second case, process memory forks while renderer_process_port is still None. This causes multiple worker processes to all try and start separate SSR servers. Since the SSR server is tied to a single port, these fail.

Tangential to this, but I'm concerned about how this design relies on a single SSR process per-host to service many upstream server processes. It'd seem to be preferable to let each server process manage it's own SSR process in a 1:1 relationship.

To fix these concerns, this PR:

1. ~~Let's the OS pick an available port automatically, rather than always using 5173 (or the value of REACTIVATED_VITE_PORT).~~
2. ~~Switches the N:1 process model to 1:1 by storing SSR server ports in a map keyed by the server process PID.~~
3. Makes express listen on a unix socket with a unique name.
