### PR TITLE
Asset file names are being replaced by 'renderer'

### DIFF
--- a/packages/reactivated/src/build.client.mts
+++ b/packages/reactivated/src/build.client.mts
@@ -66,7 +66,7 @@ const rendererConfig = {
                 inlineDynamicImports: true,
                 entryFileNames: `renderer.mjs`,
                 chunkFileNames: `renderer.mjs`,
-                assetFileNames: `renderer.[ext]`,
+                assetFileNames: `[name].[ext]`,
             },
             external,
         },


### PR DESCRIPTION
I've been having an issue with SVGs not inlined, where their server side rendered result is coming as `rendered<some_id>.svg` (which does not exist).

This merge request tries to address this issue.

<img width="290" alt="Screenshot 2024-04-17 at 16 33 14" src="https://github.com/silviogutierrez/reactivated/assets/1140912/51c18d65-69df-4a2a-98c2-f1d30f631431">
