### PR TITLE
Asset file names are being replaced by 'renderer'

### DIFF
--- a/packages/reactivated/src/build.client.mts
+++ b/packages/reactivated/src/build.client.mts
@@ -66,7 +66,7 @@ const rendererConfig = {
                 inlineDynamicImports: true,
                 entryFileNames: `renderer.mjs`,
                 chunkFileNames: `renderer.mjs`,
-                assetFileNames: `renderer.[ext]`,
+                assetFileNames: `[name].[ext]`,
             },
             external,
         },


### PR DESCRIPTION


I've been having an issue with SVGs not inlined, where their server side rendered result is coming as rendered<some_id>.svg (which does not exist).

This merge request tries to address this issue.

<img width="290" alt="print" src="https://github.com/silviogutierrez/reactivated/assets/1140912/d97b5236-92fb-4aed-96e4-5589c6dbb086">
