### PR TITLE
Improve SSR error handling

### DIFF
--- a/packages/reactivated/src/errors.tsx
+++ b/packages/reactivated/src/errors.tsx
@@ -1,0 +1,13 @@
+export interface SerializedError {
+    message: string;
+    stack: string | null;
+}
+
+export interface SSRErrorResponse {
+    error: SerializedError;
+}
+
+export const serializeError = (error: Error): SerializedError => ({
+    message: error.toString(),
+    stack: error.stack || null,
+});

--- a/packages/reactivated/src/server.mts
+++ b/packages/reactivated/src/server.mts
@@ -5,6 +5,7 @@ import http from "node:http";
 import os from "node:os";
 import react from "@vitejs/plugin-react";
 import ReactDOMServer from "react-dom/server";
+import {SSRErrorResponse, serializeError} from "./errors.js";
 import {render} from "./render.mjs";
 
 import {Helmet, HelmetProvider, HelmetServerState} from "react-helmet-async";
@@ -29,7 +30,10 @@ app.use("/_reactivated/", async (req, res) => {
         const rendered = await render(req, "", "production", "index");
         res.status(200).set({"Content-Type": "text/html"}).end(rendered);
     } catch (error) {
-        res.status(500).json({error: {}});
+        const errResp: SSRErrorResponse = {
+            error: serializeError(error as any),
+        };
+        res.status(500).json(errResp);
     }
 });
 

--- a/packages/reactivated/src/vite.mts
+++ b/packages/reactivated/src/vite.mts
@@ -6,6 +6,7 @@ import path from "path";
 import react from "@vitejs/plugin-react";
 import ReactDOMServer from "react-dom/server";
 import {define} from "./conf.js";
+import {SSRErrorResponse, serializeError} from "./errors.js";
 import type {render as renderType} from "./render.mjs";
 import type {Options} from "./conf";
 import type {RendererConfig} from "./build.client.mjs";
@@ -98,7 +99,9 @@ app.use("/_reactivated/", async (req, res) => {
         res.status(200).set({"Content-Type": "text/html"}).end(rendered);
     } catch (error) {
         vite.ssrFixStacktrace(error as any);
-        console.error(error);
-        res.status(500).json({error: {}});
+        const errResp: SSRErrorResponse = {
+            error: serializeError(error as any),
+        };
+        res.status(500).json(errResp);
     }
 });


### PR DESCRIPTION
Previously any error thrown during the the SSR rendering process resulted in this rather opaque stack trace in the Python server:

```
Internal Server Error: /
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/base.py", line 220, in _get_response
    response = response.render()
               ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/template/response.py", line 114, in render
    self.content = self.rendered_content
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/app/reactivated/templates.py", line 50, in rendered_content
    return template.render(context, self._request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/reactivated/backend.py", line 81, in render
    return render_jsx_to_string(request, serialized_context, props)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/reactivated/renderer.py", line 119, in render_jsx_to_string
    raise Exception(error["stack"])
                    ~~~~~^^^^^^^^^
KeyError: 'stack'
```

This change improves this so that the actual error message and JS stack trace are included in the Python error. Now the same error looks like this:

```
Internal Server Error: /
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/base.py", line 220, in _get_response
    response = response.render()
               ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/template/response.py", line 114, in render
    self.content = self.rendered_content
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/app/reactivated/templates.py", line 50, in rendered_content
    return template.render(context, self._request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/reactivated/backend.py", line 81, in render
    return render_jsx_to_string(request, serialized_context, props)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/reactivated/renderer.py", line 123, in render_jsx_to_string
    raise exc
reactivated.exceptions.SSRError: Error: FOO BAR is Broken
Client Stack:
Error: FOO BAR is Broken
    at Template (/app/development/client/templates/DjangoDefault.tsx:10:15)
    at renderWithHooks (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5662:16)
    at renderIndeterminateComponent (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5735:15)
    at renderElement (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5950:7)
    at renderNodeDestructiveImpl (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6108:11)
    at renderNodeDestructive (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6080:14)
    at renderContextProvider (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5924:3)
    at renderElement (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6021:11)
    at renderNodeDestructiveImpl (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6108:11)
    at renderNodeDestructive (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6080:14)
    at renderIndeterminateComponent (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5789:7)
    at renderElement (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5950:7)
    at renderNodeDestructiveImpl (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6108:11)
    at renderNodeDestructive (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6080:14)
    at renderContextProvider (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5924:3)
    at renderElement (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6021:11)
    at renderNodeDestructiveImpl (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6108:11)
    at renderNodeDestructive (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6080:14)
    at finishClassComponent (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5692:3)
    at renderClassComponent (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5700:3)
    at renderElement (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5947:7)
    at renderNodeDestructiveImpl (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6108:11)
    at renderNodeDestructive (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6080:14)
    at renderElement (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5975:9)
    at renderNodeDestructiveImpl (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6108:11)
    at renderNodeDestructive (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6080:14)
    at retryTask (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6532:5)
    at performWork (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6580:7)
    at /app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6904:12
    at scheduleWork (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:78:3)
    at startWork (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6903:3)
    at renderToStringImpl (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6977:3)
    at Module.renderToString (/app/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:7065:10)
    at render (/app/packages/reactivated/src/render.mts:121:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async file:///app/packages/reactivated/dist/vite.mjs:76:26
```