### PR TITLE
Switch to maintained fork of requests-unixsocket

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,10 @@ setuptools.setup(
     scripts=[],
     install_requires=[
         "requests>=2.25.0",
-        "requests-unixsocket>=0.3.0",
+        "requests-unixsocket2>=0.4.0",
         "mypy~=1.10.0",
         "django-stubs~=5.0.0",
         "simplejson>=3.16.0",
-        # urllib3 >= 2 is currently blocked by this issue:
-        # - https://github.com/msabramo/requests-unixsocket/issues/70
-        # - https://github.com/msabramo/requests-unixsocket/pull/69
-        "urllib3<2",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
[requests-unixsocket](https://github.com/msabramo/requests-unixsocket) is unmaintained and has an increasing number of incompatibilities. Namely:

1. `urllib3 >= 2.0` is not supported.
2. `requests >= 2.32.2` is not supported.

The second issue in particular is an issue now because it prevents us from patching [CVE-2024-35195](https://github.com/advisories/GHSA-9wx4-h78v-vm56)

This change fixes this by switches to a maintained fork of the original package: [requests-unixsocket](https://gitlab.com/thelabnyc/requests-unixsocket2). 

A full diff of the original library to the new version of the fork can be seen here: [0.3.0...r0.4.0](https://gitlab.com/thelabnyc/requests-unixsocket2/-/compare/0.3.0...r0.4.0?from_project_id=58123375&straight=false)