### PR TITLE
Add request context and props to custom renderer

### DIFF
--- a/packages/reactivated/src/build.client.mts
+++ b/packages/reactivated/src/build.client.mts
@@ -6,8 +6,8 @@ import {InlineConfig, build} from "vite";
 import {builtinModules} from "node:module";
 import {execSync} from "child_process";
 import path from "path";
-import {existsSync, mkdirSync, rmSync} from "fs";
-import {define, Options} from "./conf.js";
+import {rmSync} from "fs";
+import {define} from "./conf.js";
 import * as esbuild from "esbuild";
 import {promises as fs} from "fs";
 

--- a/packages/reactivated/src/conf.tsx
+++ b/packages/reactivated/src/conf.tsx
@@ -1,14 +1,3 @@
-import type {ClientConfig, RendererConfig} from "./build.client.mjs";
-import type {InlineConfig} from "vite";
-
-export type Options = {
-    build?: {
-        client?: (options: ClientConfig) => InlineConfig;
-        renderer?: (options: RendererConfig) => InlineConfig;
-    };
-    render?: (content: JSX.Element) => Promise<JSX.Element>;
-};
-
 export const define = () => {
     const production = process.env.NODE_ENV === "production";
     const env = {

--- a/packages/reactivated/src/generator.mts
+++ b/packages/reactivated/src/generator.mts
@@ -284,9 +284,8 @@ sourceFile.addStatements(
 );
 
 sourceFile.addStatements(`
-export type {Options} from "reactivated/dist/conf";
-export type {Renderer} from "reactivated/dist/render.mjs";
-
+import type {Renderer as GenericRenderer} from "reactivated/dist/render.mjs";
+export type Renderer = GenericRenderer<_Types["Context"]>;
 
 export const rpc = new RPC(typeof window != "undefined" ? rpcUtils.defaultRequester : null as any);
 import React from "react"

--- a/packages/reactivated/src/vite.mts
+++ b/packages/reactivated/src/vite.mts
@@ -1,24 +1,18 @@
 #!/usr/bin/env node
 
-import React from "react";
 import express from "express";
 import path from "path";
 import react from "@vitejs/plugin-react";
-import ReactDOMServer from "react-dom/server";
 import {define} from "./conf.js";
 import {SSRErrorResponse, serializeError} from "./errors.js";
 import type {render as renderType} from "./render.mjs";
-import type {Options} from "./conf";
-import type {RendererConfig} from "./build.client.mjs";
-import {resolveConfig, mergeConfig, loadConfigFromFile, InlineConfig} from "vite";
+import {InlineConfig} from "vite";
 
 // @ts-ignore
 import {cjsInterop} from "vite-plugin-cjs-interop";
 
-import {Helmet, HelmetProvider, HelmetServerState} from "react-helmet-async";
 import {vanillaExtractPlugin} from "@vanilla-extract/vite-plugin";
 
-const isProduction = process.env.NODE_ENV === "production";
 const port = process.env.REACTIVATED_VITE_PORT ?? 5173;
 const base = process.env.BASE ?? "/";
 const escapedBase = base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
Ran into a case where I need request context data in our custom SSR renderer function. Specifically, I need this for loading translated strings from context into [ttag](https://ttag.js.org/)—but this seems like it could be pretty broadly useful beyond that one use case.
