### PR TITLE
fix: update mypy from ~=1.13.0 to ~=1.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ setuptools.setup(
     install_requires=[
         "requests>=2.25.0",
         "requests-unixsocket2>=0.4.0",
-        "mypy~=1.13.0",
-        "django-stubs~=5.1.1",
+        "mypy~=1.14",
+        "django-stubs~=5.1",
         "simplejson>=3.16.0",
     ],
     classifiers=[


### PR DESCRIPTION
Dropping the patch part of the version spec should allow library consumers to update to mypy >=1.14.0, <2.0.0, without requiring reactivated to update first.