### PR TITLE
Add warning about the dist folder

### DIFF
--- a/website/server/docs/existing-projects.md
+++ b/website/server/docs/existing-projects.md
@@ -54,6 +54,10 @@ you have no other directories listed, you can just add this to your settings:
 STATICFILES_DIRS = (BASE_DIR / "static/",)
 ```
 
+> **Warning**: If your current setup of static files includes a folder `dist`, you need to 
+> rename that folder. This is because vite's build process relies on that `dist` folder and so 
+> `reactivated` intercepts all requests for static content from that folder.
+
 Now add the `JSX` template backend to your `TEMPLATES` setting. Assuming you want to
 keep your regular Django templates as well, it would look something like this:
 


### PR DESCRIPTION
As suggested, adding a note about the previously undocumented thing with the `dist` folder.

I assumed putting it under the *Existing Projects* section made the most sense and then just below the section that talks about the `STATICFILES_DIRS` setting. 