### PR TITLE
fix: infinite loops in mypy plugin for NamedTuple-based templates

### DIFF
--- a/reactivated/plugin.py
+++ b/reactivated/plugin.py
@@ -1,15 +1,24 @@
 from collections.abc import Callable
-from typing import Optional
 from typing import Type as TypingType
 from typing import TypeVar
 
-from mypy.nodes import ARG_POS, Argument, Var
+from mypy.nodes import (
+    ARG_POS,
+    MDEF,
+    Argument,
+    Block,
+    FuncDef,
+    PassStmt,
+    SymbolTableNode,
+    Var,
+)
 from mypy.plugin import AnalyzeTypeContext, ClassDefContext, Plugin
-from mypy.plugins.common import add_method
-from mypy.types import Instance, Type
+from mypy.semanal_shared import set_callable_name
+from mypy.types import CallableType, Instance, Type
+from mypy.typevars import fill_typevars
+from mypy.util import get_unique_redefinition_name
 
 T = TypeVar("T")
-CB = Optional[Callable[[T], None]]
 
 
 class ReactivatedPlugin(Plugin):
@@ -21,9 +30,9 @@ class ReactivatedPlugin(Plugin):
 
         return None
 
-    def get_class_decorator_hook(
+    def get_class_decorator_hook_2(
         self, fullname: str
-    ) -> Callable[[ClassDefContext], None] | None:
+    ) -> Callable[[ClassDefContext], bool] | None:
         if fullname in [
             "reactivated.templates.template",
             "reactivated.templates.interface",
@@ -39,41 +48,79 @@ def analyze_pick(ctx: AnalyzeTypeContext) -> Type:
     )
 
 
-def analyze_template(ctx: ClassDefContext) -> None:
+def analyze_template(ctx: ClassDefContext) -> bool:
+    info = ctx.cls.info
+
+    # Idempotency: this hook may be called multiple times per class.
+    # If render was already added by this plugin, skip.
+    if "render" in info.names:
+        sym = info.names["render"]
+        if sym.plugin_generated:
+            return True
+
     template_response = ctx.api.lookup_fully_qualified_or_none(
         "django.template.response.TemplateResponse"
     )
 
-    if template_response is None and not ctx.api.final_iteration:
-        ctx.api.defer()
-        return
+    if template_response is None or template_response.node is None:
+        return False
 
     http_request = ctx.api.lookup_fully_qualified_or_none("django.http.HttpRequest")
 
-    if http_request is None and not ctx.api.final_iteration:
-        ctx.api.defer()
-        return
+    if http_request is None or http_request.node is None:
+        return False
 
-    request_arg = Argument(
-        variable=Var(
-            "request",
-            Instance(http_request.node, []),  # type: ignore[union-attr, arg-type]
+    # Build the render(request: HttpRequest) -> TemplateResponse method.
+    #
+    # We add ONLY to info.names, not to cls.defn.defs.body. The old approach
+    # of using add_method() appends a FuncDef to the class body, which
+    # corrupts NamedTuple classes: mypy rebuilds NamedTuple info from the body
+    # on each semantic analysis pass, and the extra FuncDef causes the
+    # NamedTuple fields to be lost, triggering infinite re-analysis.
+    self_type = fill_typevars(info)
+    request_type = Instance(http_request.node, [])  # type: ignore[arg-type]
+    return_type = Instance(template_response.node, [])  # type: ignore[arg-type]
+    function_type = ctx.api.named_type("builtins.function", [])
+
+    args = [
+        Argument(Var("self"), self_type, None, ARG_POS),
+        Argument(
+            variable=Var("request", request_type),
+            type_annotation=request_type,
+            initializer=None,
+            kind=ARG_POS,
         ),
-        type_annotation=Instance(
-            http_request.node, []  # type: ignore[union-attr, arg-type]
-        ),
-        initializer=None,
-        kind=ARG_POS,
+    ]
+
+    arg_types = [a.type_annotation for a in args]
+    arg_names = [a.variable.name for a in args]
+    arg_kinds = [a.kind for a in args]
+
+    signature = CallableType(
+        arg_types,  # type: ignore[arg-type]
+        arg_kinds,
+        arg_names,
+        return_type,
+        function_type,
     )
 
-    add_method(
-        ctx,
-        "render",
-        args=[request_arg],
-        return_type=Instance(
-            template_response.node, []  # type: ignore[union-attr, arg-type]
-        ),
-    )
+    func = FuncDef("render", args, Block([PassStmt()]))
+    func.info = info
+    func.type = set_callable_name(signature, func)
+    func._fullname = info.fullname + ".render"
+    func.line = info.line
+
+    sym = SymbolTableNode(MDEF, func)
+    sym.plugin_generated = True
+
+    # If there's an existing "render" entry, rename it to avoid conflict
+    if "render" in info.names:
+        r_name = get_unique_redefinition_name("render", info.names)
+        info.names[r_name] = info.names["render"]
+
+    info.names["render"] = sym
+
+    return True
 
 
 def plugin(version: str) -> TypingType[Plugin]:

--- a/tests/mypy/mypy.ini
+++ b/tests/mypy/mypy.ini
@@ -1,0 +1,17 @@
+[mypy]
+python_version = 3.12
+show_error_codes = True
+plugins =
+    mypy_django_plugin.main,
+    reactivated.plugin
+
+[mypy.plugins.django-stubs]
+django_settings_module = tests.mypy.test_settings
+
+# Suppress errors from the reactivated library itself so that tests focus
+# only on the plugin behavior for user code in main.
+[mypy-reactivated.*]
+ignore_errors = True
+
+[mypy-sample.*]
+ignore_errors = True

--- a/tests/mypy/test_plugin.yml
+++ b/tests/mypy/test_plugin.yml
@@ -1,0 +1,207 @@
+# Tests for the reactivated mypy plugin.
+#
+# These tests verify that the plugin correctly:
+# 1. Adds render() methods to @template and @interface decorated NamedTuples
+# 2. Preserves NamedTuple field types after decoration
+# 3. Resolves Pick[Model, "field"] to the model type
+#
+# The plugin uses get_class_decorator_hook_2 (not get_class_decorator_hook)
+# and adds render() only to info.names (not to defs.body) to avoid corrupting
+# NamedTuple class info during mypy's semantic analysis passes. See the
+# detailed comments in plugin.py for the rationale.
+
+- case: template_adds_render_method
+  main: |
+    from typing import NamedTuple
+    from reactivated import template
+
+    @template
+    class MyTemplate(NamedTuple):
+        title: str
+
+    t = MyTemplate(title="hello")
+    reveal_type(t.render)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.template.response.TemplateResponse"
+
+- case: template_preserves_namedtuple_fields
+  main: |
+    from typing import NamedTuple
+    from reactivated import template
+
+    @template
+    class MyTemplate(NamedTuple):
+        name: str
+        quantity: int
+        active: bool
+
+    t = MyTemplate(name="hi", quantity=1, active=True)
+    reveal_type(t.name)  # N: Revealed type is "builtins.str"
+    reveal_type(t.quantity)  # N: Revealed type is "builtins.int"
+    reveal_type(t.active)  # N: Revealed type is "builtins.bool"
+
+- case: template_render_returns_template_response
+  main: |
+    from typing import NamedTuple
+    from django.http import HttpRequest
+    from reactivated import template
+
+    @template
+    class MyTemplate(NamedTuple):
+        value: int
+
+    t = MyTemplate(value=42)
+    request = HttpRequest()
+    response = t.render(request)
+    reveal_type(response)  # N: Revealed type is "django.template.response.TemplateResponse"
+
+- case: interface_adds_render_method
+  main: |
+    from typing import NamedTuple
+    from reactivated import interface
+
+    @interface
+    class MyInterface(NamedTuple):
+        data: str
+
+    i = MyInterface(data="test")
+    reveal_type(i.render)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.template.response.TemplateResponse"
+
+- case: multiple_templates_in_same_file
+  main: |
+    from typing import NamedTuple
+    from reactivated import template
+
+    @template
+    class First(NamedTuple):
+        a: str
+
+    @template
+    class Second(NamedTuple):
+        b: int
+
+    @template
+    class Third(NamedTuple):
+        c: bool
+
+    # All three should have render and preserve their fields
+    reveal_type(First(a="x").a)  # N: Revealed type is "builtins.str"
+    reveal_type(Second(b=1).b)  # N: Revealed type is "builtins.int"
+    reveal_type(Third(c=True).c)  # N: Revealed type is "builtins.bool"
+    reveal_type(First(a="x").render)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.template.response.TemplateResponse"
+    reveal_type(Second(b=1).render)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.template.response.TemplateResponse"
+    reveal_type(Third(c=True).render)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.template.response.TemplateResponse"
+
+- case: pick_resolves_to_model_type
+  files:
+    - path: pickmodels.py
+      content: |
+        from django.db import models
+        class Continent(models.Model):
+            name = models.CharField(max_length=100)
+            class Meta:
+                app_label = "myapp"
+  main: |
+    from reactivated import Pick
+    from pickmodels import Continent
+    x: Pick[Continent, "name"]
+    reveal_type(x)  # N: Revealed type is "pickmodels.Continent"
+
+- case: template_with_cross_module_model_references
+  # This test exercises the scenario that triggers infinite re-analysis with
+  # the old plugin: @template classes in a module that imports Django models
+  # with complex relationships. The model import chain forces mypy to
+  # re-analyze the module containing the @template class multiple times.
+  # With the old add_method() approach, each re-analysis would corrupt the
+  # NamedTuple body, causing fields to be lost and triggering further
+  # re-analysis in an infinite loop.
+  files:
+    - path: mymodels.py
+      content: |
+        from django.db import models
+        class Author(models.Model):
+            name = models.CharField(max_length=100)
+            class Meta:
+                app_label = "myapp"
+        class Book(models.Model):
+            title = models.CharField(max_length=200)
+            author = models.ForeignKey(Author, on_delete=models.CASCADE, related_name="books")
+            class Meta:
+                app_label = "myapp"
+    - path: myviews.py
+      content: |
+        from typing import NamedTuple
+        from reactivated import Pick, template
+        from mymodels import Author, Book
+
+        @template
+        class AuthorDetail(NamedTuple):
+            author: Pick[Author, "name"]
+            is_preview: bool
+
+        @template
+        class BookDetail(NamedTuple):
+            book: Pick[Book, "title"]
+            is_preview: bool
+  main: |
+    from myviews import AuthorDetail, BookDetail
+    from mymodels import Author, Book
+
+    a = AuthorDetail(author=Author(), is_preview=False)
+    reveal_type(a.author)  # N: Revealed type is "mymodels.Author"
+    reveal_type(a.is_preview)  # N: Revealed type is "builtins.bool"
+    reveal_type(a.render)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.template.response.TemplateResponse"
+
+    b = BookDetail(book=Book(), is_preview=True)
+    reveal_type(b.book)  # N: Revealed type is "mymodels.Book"
+    reveal_type(b.is_preview)  # N: Revealed type is "builtins.bool"
+    reveal_type(b.render)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.template.response.TemplateResponse"
+
+- case: template_with_pick_field
+  files:
+    - path: tpfmodels.py
+      content: |
+        from django.db import models
+        class Continent(models.Model):
+            name = models.CharField(max_length=100)
+            class Meta:
+                app_label = "myapp"
+  main: |
+    from typing import NamedTuple
+    from reactivated import Pick, template
+    from tpfmodels import Continent
+
+    @template
+    class ContinentView(NamedTuple):
+        continent: Pick[Continent, "name"]
+        is_preview: bool
+
+    t = ContinentView(continent=Continent(name="Asia"), is_preview=False)
+    reveal_type(t.continent)  # N: Revealed type is "tpfmodels.Continent"
+    reveal_type(t.is_preview)  # N: Revealed type is "builtins.bool"
+    reveal_type(t.render)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.template.response.TemplateResponse"
+
+- case: template_rejects_non_namedtuple
+  # @template's TypeVar is bounded to NamedTuple, so plain classes
+  # should produce a type error.
+  main: |
+    from reactivated import template
+
+    @template
+    class PlainTemplate:  # E: Value of type variable "T" of "template" cannot be "PlainTemplate"  [type-var]
+        def __init__(self, title: str) -> None:
+            self.title = title
+
+- case: template_with_existing_render_method
+  # If a class already defines its own render(), the plugin should
+  # override it with the correct signature.
+  main: |
+    from typing import NamedTuple
+    from reactivated import template
+
+    @template
+    class HasRender(NamedTuple):
+        value: int
+        def render(self) -> str:
+            return ""
+
+    t = HasRender(value=1)
+    reveal_type(t.render)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.template.response.TemplateResponse"

--- a/tests/mypy/test_settings.py
+++ b/tests/mypy/test_settings.py
@@ -1,0 +1,16 @@
+"""Minimal Django settings for mypy plugin tests.
+
+Uses sqlite3 so the tests don't require psycopg2 or a running database.
+"""
+
+SECRET_KEY = "test-secret-key"
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+]
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}


### PR DESCRIPTION
The mypy plugin's analyze_template hook used add_method() from mypy.plugins.common, which appends a FuncDef to the NamedTuple class body (cls.defn.defs.body). When mypy re-analyzes a module (e.g. due to cross-module dependencies like FK relationships between models), it rebuilds NamedTuple TypeInfo from the class body. The extra FuncDef from the previous pass corrupts the rebuild — NamedTuple fields are lost, which triggers further re-analysis in an infinite loop.

Changes

- Switch from get_class_decorator_hook to get_class_decorator_hook_2, which runs in a later semantic analysis pass after placeholders have been resolved. This eliminates the need for manual ctx.api.defer() / final_iteration checks.
- Replace add_method() with direct construction of the FuncDef and SymbolTableNode, adding the render method only to info.names — never to defs.body. This is the core fix: mypy can no longer see the synthetic method when it rebuilds the NamedTuple from the class body.
- Add an idempotency guard (sym.plugin_generated) so repeated invocations of the hook are a no-op.
- Return False (request deferral) instead of silently continuing when TemplateResponse or HttpRequest types haven't resolved yet.
- Guard against SymbolTableNode.node being None.
- Remove unused CB type alias and Optional import.