### PR TITLE
Add explicit HTTP method to RPC requester and downstream fixes

### DIFF
--- a/docs/subtree.md
+++ b/docs/subtree.md
@@ -64,6 +64,9 @@ cd ../..
 
 # Initial build (required once before dev server works):
 npx tsc -p upstream/reactivated/packages/reactivated/tsconfig.json
+
+# Regenerate your app's client schema against the vendored source:
+python manage.py generate_client_assets
 ```
 
 ## Live editing
@@ -85,9 +88,22 @@ npx tsc -p upstream/reactivated/packages/reactivated/tsconfig.json
 npx tsc -p upstream/reactivated/packages/reactivated/tsconfig.json --watch
 ```
 
-**Note for CI and Docker**: `npm ci` copies instead of symlinking, so re-run
-`npm install ./upstream/reactivated/packages/reactivated` after compiling the
-TypeScript to update the copy with the freshly built `dist/`.
+## CI and Docker
+
+CI and Docker images must build reactivated from source. The sequence:
+
+1. Install Python deps (`uv sync` — installs reactivated from local source)
+2. Install Node deps (`npm ci` — gets peer deps like `json-schema-to-typescript`,
+   `tsc`)
+3. Generate TypeScript types (`python scripts/generate_types.py`)
+4. Compile TypeScript (`tsc` in `packages/reactivated/`)
+5. Re-install reactivated (`npm install ./upstream/reactivated/packages/reactivated`)
+   — required because `npm ci` copies instead of symlinking, so the copy must be
+   updated with the freshly built `dist/`
+
+In Docker, use `uv sync --no-editable` since live editing isn't needed in production.
+Exclude subtree dev artifacts from the build context in `.dockerignore` (`.venv/`,
+`node_modules/`, `sample/`, `development/`, `website/`, `tests/`).
 
 ## Why not `git subtree` or `git submodule`?
 
@@ -176,6 +192,21 @@ back:
 6. After the PR merges, pull the squashed result back down using the patch flow below.
    This picks up any fixes made during review.
 
+### Common pitfalls
+
+- **Generate the patch from the full subtree diff — don't cherry-pick files.** A
+  hand-picked patch is how a utility lands upstream without its tests (it happened:
+  #451 shipped `flatten_schema` bare; #453 had to port the test after the fact).
+- **npm peer dep conflicts**: This repo's integration test creates a fresh project
+  with no lock file, so it resolves peer deps from the registry. If upstream packages
+  bumped (e.g. `tsx` pulling a newer `esbuild`), bump pinned peer deps in
+  `packages/reactivated/package.json` and regenerate `package-lock.json`.
+- **Prettier on generated files**: Auto-generated files like `client/schema.tsx` must
+  be in `.gitignore` (prettier reads `.gitignore` to skip files). Check both `sample/`
+  and `website/` directories.
+- **Lock files**: rebuild them inside this repo's nix-shell
+  (`npm install --package-lock-only`).
+
 ## Pulling upstream changes
 
 When this repo has new changes you want in your project (whether from your own merged
@@ -230,11 +261,17 @@ The vendored source has its own lint configs. To avoid conflicts with your proje
 linters, exclude `upstream/reactivated/` from them:
 
 - **ruff**: `exclude = ["upstream/reactivated/"]` in `pyproject.toml`
-- **mypy**: add `upstream/reactivated/` to `exclude` in `mypy.ini`, plus
-  `follow_imports = silent` for `reactivated` and `reactivated.*` modules (suppresses
-  errors within reactivated source while still type-checking your usage of it)
+- **mypy**: add `upstream/reactivated/` to `exclude` in `mypy.ini`, add
+  `./upstream/reactivated` to `mypy_path`, plus `follow_imports = silent` for
+  `reactivated` and `reactivated.*` modules (suppresses errors within reactivated
+  source while still type-checking your usage of it)
+- **eslint**: add `"upstream/reactivated/"` to your ignores
 - **prettier**: add `upstream/reactivated/packages/reactivated/src/generated.tsx` to
   `.gitignore` (prettier reads `.gitignore` patterns by default)
+- **shellcheck/shfmt/nixfmt and fix scripts**: if your lint scripts enumerate files
+  with `git ls-files`, filter the subtree out
+  (`grep -v '^upstream/reactivated/'`) — the vendored shell/nix files follow this
+  repo's conventions, not yours
 
 ## Running reactivated's test suite
 
@@ -259,7 +296,12 @@ identically with the published packages:
    `[tool.uv.sources]` override, then `uv sync`.
 2. In `package.json`: change `"file:upstream/reactivated/packages/reactivated"` to
    `"^LATEST_VERSION"`, then `npm install`.
-3. Remove any subtree-specific build steps from CI and Docker (type generation, tsc,
-   re-install of the built package).
-4. Remove the lint exclusions.
+3. Remove any subtree-specific build steps from CI and Docker (the source COPY lines,
+   type generation, tsc, re-install of the built package — `uv sync` and `npm ci`
+   stay and pull the published packages instead). The runtime layout is unchanged:
+   the published npm package puts built files in the same `node_modules` locations.
+4. Remove the lint exclusions and any `.dockerignore` entries for the subtree.
 5. `rm -rf upstream/reactivated/`
+
+Then verify: `uv sync && npm install`, regenerate client assets
+(`python manage.py generate_client_assets`), and run your project's checks.

--- a/packages/reactivated/src/rpc.tsx
+++ b/packages/reactivated/src/rpc.tsx
@@ -36,16 +36,23 @@ type JSONValue =
 export type Requester = (
     url: string,
     payload: JSONValue | null,
+    method: "GET" | "POST",
 ) => Promise<RequesterResult>;
 
-export const defaultRequester: Requester = async (url, payload) => {
+export const defaultRequester: Requester = async (url, payload, method) => {
     try {
+        // The method is authoritative (it comes from the server's RPC
+        // declaration), not inferred from whether a payload is present. A POST
+        // serializes the payload exactly as given — including a literal `null` when
+        // the RPC's input is omitted — so the server receives the typed value it
+        // expects (e.g. `null` for an optional `Form | None` input).
+        const isGet = method === "GET";
         const response = await fetch(url, {
-            method: payload == null ? "GET" : "POST",
-            body: payload == null ? null : JSON.stringify(payload),
+            method,
+            body: isGet ? null : JSON.stringify(payload),
             headers: {
                 Accept: "application/json",
-                ...(payload != null ? {"Content-Type": "application/json"} : {}),
+                ...(isGet ? {} : {"Content-Type": "application/json"}),
                 "X-CSRFToken":
                     getCookieFromCookieString("csrftoken", document.cookie) ?? "",
             },

--- a/packages/reactivated/src/vite.mts
+++ b/packages/reactivated/src/vite.mts
@@ -63,6 +63,17 @@ const rendererConfig: InlineConfig = {
 
 export const vite = await createServer(rendererConfig);
 
+// Pre-warm SSR modules
+console.log("[warmup] Pre-loading SSR modules...");
+const ssrWarmupStart = Date.now();
+try {
+    await vite.ssrLoadModule("reactivated/dist/render.mjs");
+    await vite.ssrLoadModule("@reactivated/template");
+    console.log(`[warmup] SSR modules loaded in ${Date.now() - ssrWarmupStart}ms`);
+} catch (e: any) {
+    console.log(`[warmup] SSR warmup error (non-fatal): ${e.message}`);
+}
+
 app.use(vite.middlewares);
 app.use(express.json({limit: "200mb"}));
 

--- a/reactivated/rpc/core.py
+++ b/reactivated/rpc/core.py
@@ -308,7 +308,11 @@ class Router(Generic[TAnonymous]):
                 if param_type in DJANGO_CONVERTERS:
                     rpc_params.append((param_type, param_name))
                 elif param_type is NoneType:
-                    pass
+                    raise TypeError(
+                        f"RPC '{rpc_call.__name__}' has a None-typed param "
+                        f"'{param_name}'. Declare a no-body RPC by omitting the "
+                        f"param entirely, e.g. def {rpc_call.__name__}(request)."
+                    )
                 else:
                     assert rpc_form is None, (
                         f"Multiple body params in {rpc_call.__name__}"
@@ -2436,7 +2440,7 @@ def generate_client_schema(skip_cache: bool = False) -> None:
         EXTRA += f"""
         export async function {call_name}({args_str}) {{
             const {{rpc}} = await import("@reactivated");
-            return rpc.requester({url_expr}, {payload_expr}) as unknown as Promise<RPCResult<Schema["{rpc_output_name}"]>>;
+            return rpc.requester({url_expr}, {payload_expr}, "{rpc_call["method"]}") as unknown as Promise<RPCResult<Schema["{rpc_output_name}"]>>;
         }}
         """
 

--- a/reactivated/rpc/forms.py
+++ b/reactivated/rpc/forms.py
@@ -7,7 +7,16 @@ import inspect
 import json
 import logging
 from types import NoneType, UnionType
-from typing import Any, Callable, Literal, TypeVar, cast, get_origin, get_type_hints
+from typing import (
+    Any,
+    Callable,
+    Literal,
+    TypeVar,
+    Union,
+    cast,
+    get_origin,
+    get_type_hints,
+)
 
 from pydantic import EmailStr, Field, SecretStr, model_validator
 from pydantic_core import PydanticUndefined
@@ -377,12 +386,13 @@ def get_form_schema(form_cls: type) -> dict[str, Any]:
                 # Use explicitly provided options
                 options = list(form_options)
             else:
-                # Extract options from Literal/Enum type
+                # Extract options from Literal/Enum type. Optional types come
+                # in two spellings: unions of plain classes
+                # (``SomeEnum | None``) are UnionType instances, while unions
+                # involving typing forms (``Literal[...] | None``) are
+                # typing.Union generics. get_origin normalizes both.
                 actual_type = base_type
-                if (
-                    hasattr(base_type, "__origin__")
-                    and base_type.__origin__ is UnionType
-                ):
+                if get_origin(base_type) in (Union, UnionType):
                     non_none = [a for a in base_type.__args__ if a is not NoneType]
                     if non_none:
                         actual_type = non_none[0]

--- a/tests/rpc.py
+++ b/tests/rpc.py
@@ -28,6 +28,7 @@ from reactivated.rpc.core import (
     pick,
 )
 from reactivated.rpc.forms import get_form_schema
+from reactivated.rpc.utils import flatten_schema
 
 
 def unique_email() -> str:
@@ -69,6 +70,17 @@ class SelectWithEmptyOptionForm(BaseModel):
         required=False,
         options=(("a", "Option A"), ("b", "Option B")),
     )
+
+
+class _Stage(enum.Enum):
+    LEAD = "Lead"
+    SOLD = "Sold"
+
+
+@form()
+class OptionalSelectForm(BaseModel):
+    status: Literal["NEW", "SOLD"] | None = FormField(widget="select", required=False)
+    stage: _Stage | None = FormField(widget="select", required=False)
 
 
 # Module-level picks for schema generation and .returns tests.
@@ -338,6 +350,22 @@ def test_select_with_empty_option_schema() -> None:
     assert schema["defaults"]["category"] is None
 
 
+def test_optional_select_extracts_options() -> None:
+    # Optional select fields must extract options from the non-None union
+    # member, whether the union is a UnionType instance (`SomeEnum | None`)
+    # or a typing.Union generic (`Literal[...] | None`).
+    schema = get_form_schema(OptionalSelectForm)
+
+    assert schema["fields"]["status"]["options"] == [
+        ("NEW", "NEW"),
+        ("SOLD", "SOLD"),
+    ]
+    assert schema["fields"]["stage"]["options"] == [
+        ("LEAD", "Lead"),
+        ("SOLD", "Sold"),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_get_method_handling(settings: Any, rf: Any) -> None:
     settings.DEBUG = False
@@ -371,6 +399,14 @@ async def test_get_method_handling(settings: Any, rf: Any) -> None:
     request.user = AnonymousUser()
     response = await rpc.handlers["rpc_post_only"]["handler"](request)
     assert response.status_code == 200
+
+    # A None-typed body param is forbidden at registration; a no-body RPC is
+    # declared by omitting the param entirely (as post_only above does).
+    with pytest.raises(TypeError, match="None-typed param"):
+
+        @rpc(anyone, atomic_requests=False)
+        def none_body(request: HttpRequest, form: None) -> None:
+            pass
 
 
 @pytest.mark.asyncio
@@ -905,6 +941,32 @@ def test_schema_generation_with_extra_fields(settings: Any, tmp_path: Any) -> No
     assert "builtins.list[builtins.tuple[builtins.str, builtins.int]]" in generated
 
     sys.path.remove(str(schema_dir))
+
+
+class _Color(enum.StrEnum):
+    RED = "RED"
+    GREEN = "GREEN"
+
+
+class _FlattenTarget(Pick):
+    action: Literal["CREATE"]
+    color: _Color
+    items: list[Pick]
+
+
+def test_flatten_schema() -> None:
+    schema = _FlattenTarget.model_json_schema()
+    assert "$defs" in schema
+
+    result = flatten_schema(schema)
+    serialized = json.dumps(result)
+
+    assert "$defs" not in result
+    assert "$ref" not in serialized
+    assert '"title"' not in serialized
+    assert '"format"' not in serialized
+    assert result["properties"]["action"]["const"] == "CREATE"
+    assert result["properties"]["color"]["enum"] == ["RED", "GREEN"]
 
 
 def test_type_to_str_pick_holder() -> None:


### PR DESCRIPTION
## Summary

Syncs up everything the Joy and MCR vendored subtrees have accumulated on top of upstream since v0.50.1. After this merges, both projects can pull down cleanly and all three trees converge.

### From Joy

- **Require an explicit HTTP method in the RPC requester.** The method now comes from the server's RPC declaration (passed as a third argument by the generated schema) instead of being inferred from payload presence. Previously, a POST RPC with an omitted optional input (`Form | None`) serialized no body and silently degraded to a GET; now a POST always serializes its payload exactly as given, including a literal `null`. ⚠️ **Breaking for custom `Requester` implementations** — they must accept the new `method` parameter. Warrants a minor version bump.
- **Reject None-typed RPC body params at registration** with a clear `TypeError` (previously silently ignored). A no-body RPC is declared by omitting the param entirely.
- **Pre-warm SSR modules in the Vite dev server** for a faster first render (non-fatal on failure).

### From MCR

- **Extract select options from optional Literal/Enum field types.** `get_form_schema` skipped option extraction when the field type was an optional union. MCR's fix covered `SomeEnum | None` (a `UnionType` instance); this generalizes it via `get_origin` to also cover `Literal[...] | None`, which is a `typing.Union` generic (typing special forms implement `|` that way), with tests for both spellings.
- **Port the `test_flatten_schema` test** that shipped without coverage in #451.
- **Expand `docs/subtree.md`**: client schema regeneration step, full CI/Docker build sequence, and a common-pitfalls section for the patch-based sync flow.

## Test plan

- `pytest tests/rpc.py`: 23 passed (vs 21 on main). The new `test_optional_select_extracts_options` fails without the forms fix; the None-param check runs inside `test_get_method_handling`. The 6 Postgres-connection errors are identical on unmodified main — environmental.
- `ruff check` and `ruff format --check` pass on changed Python files.
- `tsc -p packages/reactivated/tsconfig.json` compiles cleanly with the new `Requester` signature after regenerating types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)