### PR TITLE
Add build_subtree.sh for building vendored checkouts

### DIFF
--- a/docs/subtree.md
+++ b/docs/subtree.md
@@ -51,23 +51,31 @@ reactivated = { path = "./upstream/reactivated", editable = true }
 
 ## Build steps
 
-After cloning or pulling changes to the subtree:
+After cloning or pulling changes to the subtree, install dependencies, run the
+subtree's own build script from your project root, then regenerate your app's
+schemas:
 
 ```bash
 uv sync                          # Install Python deps (editable reactivated)
 npm install                      # Install Node deps (symlinks to subtree)
 
-# Generate types (writes packages/reactivated/src/generated.tsx):
-cd upstream/reactivated
-PATH=$(pwd)/../../node_modules/.bin:$PATH python scripts/generate_types.py
-cd ../..
-
-# Initial build (required once before dev server works):
-npx tsc -p upstream/reactivated/packages/reactivated/tsconfig.json
-
-# Regenerate your app's client schema against the vendored source:
+./upstream/reactivated/packages/reactivated/scripts/build_subtree.sh
 python manage.py generate_client_assets
 ```
+
+The script does, in order:
+
+1. Generate types (writes `packages/reactivated/src/generated.tsx`).
+2. Compile the TypeScript package to `dist/` (required once before the dev server
+   works).
+3. Re-run `npm install` against the subtree package — its `bin` entries point into
+   `dist/`, which only exists after the compile.
+
+It builds the framework only; it never executes your application. Regenerating the
+client schema and server `pick_schema` (`manage.py generate_client_assets`) runs
+with your app's settings and models, so that call stays in your hands — make it
+after the script, from your project's `setup` helper, CI setup action, and release
+script, so every environment builds the same way.
 
 ## Live editing
 

--- a/packages/reactivated/package.json
+++ b/packages/reactivated/package.json
@@ -23,6 +23,7 @@
     "author": "",
     "bin": {
         "setup_environment.sh": "./scripts/setup_environment.sh",
+        "build_subtree.sh": "./scripts/build_subtree.sh",
         "generate_client_assets": "./dist/generator.mjs",
         "generate_client_constants": "./dist/generator/constants.mjs",
         "build.client": "./dist/build.client.mjs",

--- a/packages/reactivated/scripts/build_subtree.sh
+++ b/packages/reactivated/scripts/build_subtree.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Builds the vendored reactivated subtree in a project that consumes it at
+# upstream/reactivated/ (see docs/subtree.md). Run from the project root,
+# after `npm install` and `uv sync`.
+set -euo pipefail
+
+ROOT="$PWD"
+SUBTREE="$ROOT/upstream/reactivated"
+
+if [ ! -d "$SUBTREE" ]; then
+    echo "No upstream/reactivated/ found. Run from the root of a project that vendors reactivated." >&2
+    exit 1
+fi
+
+# Generate packages/reactivated/src/generated.tsx from the Python types.
+(cd "$SUBTREE" && PATH="$ROOT/node_modules/.bin:$PATH" python scripts/generate_types.py)
+
+# Compile the TypeScript package to dist/.
+"$ROOT/node_modules/.bin/tsc" --project "$SUBTREE/packages/reactivated/tsconfig.json"
+
+# Re-link the file: dependency: its bin entries point into dist/, which only
+# now exists.
+npm install ./upstream/reactivated/packages/reactivated
+
+# The framework is now built. Regenerate your app's schemas against it:
+#     python manage.py generate_client_assets
+# That call belongs to the consumer (it runs with your app's settings), so it
+# is intentionally not made here.


### PR DESCRIPTION
Projects that vendor the framework at `upstream/reactivated/` (per `docs/subtree.md`) each re-implement the same build sequence — `generate_types.py`, `tsc`, and a second `npm install` to re-link the `file:` dependency's `bin` entries — in their setup helpers, CI setup actions, and release scripts, with slight drift between copies.

This ships the sequence as `packages/reactivated/scripts/build_subtree.sh`, next to `setup_environment.sh` (same placement and consumption pattern: downstream references the vendored path directly, and like `setup_environment.sh` it only calls downward — it builds the framework's own artifacts and never executes the consumer's application). It is also declared in the package's `bin`.

Consumers run, from their project root:

```bash
./upstream/reactivated/packages/reactivated/scripts/build_subtree.sh
python manage.py generate_client_assets
```

`generate_client_assets` is deliberately **not** inside the script: it runs with the app's settings and models, so it's a function the library provides and the consumer calls — same contract as `setup_environment.sh` itself.

`docs/subtree.md`'s manual build-steps block is replaced with the above. Verified end-to-end against a real vendored checkout (miamicabinetrefacing.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)