### PR TITLE
Document research on supporting pyright, basedpyright, and ty

### DIFF
--- a/docs/codegen-transform.md
+++ b/docs/codegen-transform.md
@@ -1,0 +1,173 @@
+# codegen_transform: a declarative hook for generated types
+
+Draft proposal to pitch to basedpyright and ty. It builds on the research in
+[type-checkers.md](type-checkers.md), but nothing in it is reactivated-specific.
+That's deliberate: it only lands if it covers other libraries too, the same way
+dataclass_transform landed by covering attrs, pydantic, and SQLModel at once.
+
+## The problem
+
+Python is full of factories that build classes at runtime:
+
+```python
+class StagedMeal(pick(models.Meal, fields=["name", "hour"])):
+    pass
+
+UserForm = modelform_factory(User, fields=["email"])
+Config = create_model("Config", retries=(int, ...))
+```
+
+Type checkers can't see through these. The return type depends on things
+outside the expression: model metadata, a database, a schema file. So the
+factory returns Any and the library ships an escape hatch instead of types.
+
+There are two known ways out today, and both are bad.
+
+The first is a plugin system. mypy has one, and reactivated uses it. But
+plugins run third-party code inside the checker: they add latency to every
+keystroke in the language server, they poison caches, they crash the host, and
+they freeze internal APIs the checker wants to refactor. pyright and ty have
+both said no to plugins, and having maintained a mypy plugin for years, I
+can't blame them.
+
+The second is hard-coding libraries into the checker, which is where ty is
+headed (pydantic support already shipped in their core). It works, but it
+doesn't scale past the top five packages on PyPI, and it will never reach a
+library like this one.
+
+## The observation
+
+Look at what the reactivated mypy plugin actually does. It doesn't compute
+types. It computes a *name*: take the module where `pick()` was called,
+replace dots with underscores, append the class name, and look that up in a
+generated module called `pick_schema`. The real type intelligence lives in
+`pick_schema.py`, which is ordinary Python that a build step wrote to disk and
+that any checker already analyzes with no special logic at all.
+
+The arbitrary, messy, library-specific work (reading Django model metadata,
+walking foreign keys, deciding nullability) happens at build time, in the
+library's own process, where it can be tested and versioned and seen in diffs.
+The only thing the checker is asked to do is resolve a symbol. That is the
+checker working exactly as built, just with an updated reference.
+
+Plugins run inside the checker. Transforms run before it. The missing piece is
+a spec'd way for the checker to see the transform's output.
+
+## The proposal
+
+A decorator on the factory, declared once by the library author, shipped with
+the package. No per-project configuration, same as dataclass_transform:
+
+```python
+@codegen_transform(
+    module="pick_schema",
+    name="{caller_module_underscored}_{binding_name}",
+)
+def pick(model: type[Model], *, fields: list[str]) -> type[Any]: ...
+```
+
+Semantics, kept narrow on purpose:
+
+1. The hook applies only when the decorated callable is invoked as the entire
+   base-class expression of a `class` statement, or as the entire right-hand
+   side of a simple assignment. Anywhere else, the declared return type
+   applies, unchanged.
+2. `binding_name` is the class name (or the assignment target).
+   `caller_module` is the module containing the call. The template language is
+   a closed set of tokens with plain substitution. No conditionals, no
+   expressions, no code. That restriction is the whole point: this stays data.
+3. The checker resolves `module` through its normal import resolution, from
+   the call site's file. It renders `name` and looks the symbol up. If it
+   resolves to a class, that class is the type of the call expression (so in
+   base position, the user's class becomes an ordinary subclass of it). If
+   not, the declared return type applies.
+4. At runtime the decorator is identity, like dataclass_transform.
+
+Note what the fallback buys. The feature is strictly a refinement of the
+declared return type, never a loosening. A checker that doesn't implement it
+sees exactly what it sees today: Any. A checker that does implement it, but
+finds no generated symbol (the user hasn't run codegen yet), also degrades to
+today's behavior. And a checker can go one better than the mypy plugin ever
+did: offer an opt-in diagnostic for "generated symbol not found," so strict
+codebases can turn the silent Any into an error. Plugins never gave anyone
+that.
+
+## Who else this covers
+
+Any library whose current answer is "sorry, that returns Any" plus a codegen
+story:
+
+- `pydantic.create_model(...)` is untypeable today. A sidecar that emits the
+  concrete models makes it precise.
+- Django's own `modelform_factory(Model, fields=[...])` is the identical
+  shape.
+- Functional `Enum("Color", names)` built from data files. SQL-first row
+  types in the aiosql style. Any ORM or RPC layer that derives classes from a
+  schema the checker can't read.
+
+The pattern is "dynamic class factory plus codegen sidecar," and once you
+start looking for it you see it everywhere.
+
+## What the checker implements
+
+Very little, and all of it with existing machinery. From the research in
+type-checkers.md:
+
+- pyright and basedpyright already dispatch on a callable's fully qualified
+  name (`functionTransform.ts`), already resolve symbols from arbitrary
+  modules (`getTypeOfModule`), and already pull unimported modules into the
+  program on demand. The one real gap is an implicit import edge so that
+  regenerating the module invalidates dependents, and there's in-tree
+  precedent for that too. Around 150 lines total.
+- ty gets invalidation for free: module resolution and symbol lookup are
+  already salsa-tracked queries, so regenerating the file re-infers exactly
+  the classes that consulted it. The insertion point
+  (`infer_class_definition`) already does a full symbol swap for
+  `typing.NamedTuple`. Similar line count.
+
+No new caching, no sandboxing, no plugin API to stabilize. Projects that don't
+use the decorator pay nothing.
+
+## Objections
+
+*Just import the generated class directly.* Then the generated name becomes
+user-facing API and the factory call stops being the single source of truth.
+Users write natural code; codegen mirrors it. The mypy plugins that exist are
+the demand proof.
+
+*Template micro-languages grow.* The token set is closed and versioned by the
+spec. It starts at three tokens. dataclass_transform survived the same
+pressure on field specifiers.
+
+*Why not derive the type from the call arguments, dataclass_transform-style?*
+Because in general you can't. `pick(models.Meal, fields=["name"])` depends on
+what `Meal` declares in another file, and other factories depend on databases
+or schema documents. That residue is exactly what plugins were covering, and
+exactly what build time handles better.
+
+*Soundness.* The checker trusts the generated file precisely as much as it
+trusts any other source file on the path, because that's what it is. Checked
+source, visible in diffs.
+
+## How this lands
+
+basedpyright first. They already ship basedtyping as the home for
+checker-recognized extensions, so this arrives as
+`basedtyping.codegen_transform` plus the ~150 line implementation. Show up
+with the branch, tests in their sample format, and a diagnostic diff across
+their OSS corpus proving it's inert unless opted into. Their CI makes that
+claim checkable, which is worth more than any amount of persuasion.
+
+ty second, argued in their own words. Their FAQ prefers "well-specified
+features" over plugins, and this is one, smaller and more general than the
+pydantic support they hand-wrote. Ship it behind ty_extensions, their existing
+home for intrinsics. Part of the pitch is frankly economic: this is how they
+avoid writing a thousand lines of core support per library forever.
+
+Then the typing spec. dataclass_transform went typing_extensions experiment,
+then PEP, then spec. Same path: two checker implementations, two or three
+unrelated consumer libraries, then a write-up for the typing council as
+dataclass_transform for code generators. mypy comes last, and the sell there
+is retirement: this lets them deprecate the dynamic-class corner of the plugin
+API, and it gives libraries like this one a single code path across every
+checker.

--- a/docs/type-checkers.md
+++ b/docs/type-checkers.md
@@ -1,0 +1,173 @@
+# Supporting pyright, basedpyright, and ty
+
+Research notes on porting the `pick()` mypy plugin to the other type checkers.
+Investigated July 2026 against pyright 1.1.411, basedpyright 1.39.9 (based on
+pyright 1.1.411), and ty 0.0.59.
+
+## What the mypy plugin actually does
+
+The whole plugin reduces to one move. When mypy sees:
+
+```python
+class StagedMeal(pick(models.Meal, fields=["name", "hour"])):
+    pass
+```
+
+the `get_dynamic_class_hook` in `reactivated/plugin.py` fires on the call to
+`pick`. It computes a name from the defining module and class name
+(`server.journal.nutrition` + `StagedMeal` becomes
+`server_journal_nutrition_StagedMeal`), looks that up in the generated
+`pick_schema` module, and swaps the symbol table entry for `StagedMeal` to
+point at the generated class. If the generated symbol doesn't exist yet
+(schema not regenerated), the class falls back to Any instead of erroring.
+
+None of the other checkers have a plugin system, and none plan to add one.
+pyright's docs reject plugins outright (`docs/mypy-comparison.md` in their
+repo). ty's typing FAQ says the same, though they are adding hard-coded
+support for specific libraries directly in core (pydantic already shipped).
+So the question is: how hard is it to hard-code this one behavior in a fork?
+
+Answer: not hard. The code is 100-300 lines in each. The real costs are fork
+maintenance and distribution.
+
+## Half the feature already works everywhere
+
+`pick()` is annotated `-> Any`. All three checkers already tolerate an Any
+base class silently:
+
+- pyright pushes Any into `baseClasses` with no diagnostic
+  (`typeEvaluator.ts`, in `getTypeOfClass`), and member lookup on a class
+  with Any in its MRO degrades to Unknown (`typeUtils.ts`,
+  `getClassMemberIterator`).
+- ty converts a dynamic base into `ClassBase::Dynamic`
+  (`types/class_base.rs`), producing an MRO of `[StagedMeal, Any, object]`.
+  Attribute access falls back to the dynamic type.
+
+So stock pyright, basedpyright, and ty give us the plugin's fallback behavior
+today, unchanged. Only the positive half needs code: resolving the generated
+class from `pick_schema` when it exists.
+
+## One design change from the mypy plugin
+
+The mypy plugin replaces the `StagedMeal` symbol wholesale. In both pyright
+and ty, the natural move is to substitute the base class instead: the
+`pick(...)` call's type becomes the generated class, and `StagedMeal` is an
+ordinary subclass of it. Attribute typing, hover, completion, and
+go-to-definition come out the same or better, it matches what actually
+happens at runtime, and it avoids fighting each checker's declaration
+machinery. Worth adopting if the mypy plugin is ever rewritten.
+
+## pyright
+
+Every piece needed already exists, with precedent:
+
+- Special-casing calls by fully qualified name is routine.
+  `analyzer/functionTransform.ts` is a post-call return-type rewriter
+  dispatched on `functionType.shared.fullName` (used today for
+  `functools.total_ordering`). This is structurally the same thing as mypy's
+  dynamic class hook. `NamedTuple(...)`, functional `Enum(...)`, `NewType`,
+  and 3-arg `type(...)` all go through similar dispatch in
+  `typeEvaluator.ts`.
+- Cross-module lookup exists: `getTypeOfModule(node, symbolName, nameParts)`
+  in `typeEvaluator.ts` resolves a symbol from an arbitrary module. It powers
+  `getTypingType`.
+- The generated module gets pulled into the program automatically:
+  `Program._lookUpImport` resolves and calls `addTrackedFile` for modules no
+  user file imports. `pick_schema` just needs to be on the search path.
+- Invalidation needs one line. Evaluator-time lookups create no import edge,
+  so regenerating `pick_schema.py` would leave stale types in the language
+  server. `sourceFile.ts` `_resolveImports` already injects implicit imports
+  into every file (`builtins`, `_typeshed._type_checker_internals`); adding
+  `pick_schema` there (with `skipMissingImport`) makes it a real dependency
+  edge, and the standard file watcher handles the rest.
+
+Estimate: 150-300 lines. A transform in `functionTransform.ts` (~60-100
+lines), two lines to expose `getTypeOfModule` on the evaluator interface, one
+line in `_resolveImports`, plus tests.
+
+The catch is distribution. Pylance bundles its own closed pyright, so VS Code
+users on Pylance can't use a fork. You'd ship the fork as its own language
+server and point editors at it, which is exactly what basedpyright already
+does. That makes forking plain pyright the worst option: same patch, but you
+do the upstream tracking yourself and build the packaging story from scratch.
+
+## basedpyright
+
+The recommended target. Same insertion points as pyright (it tracks upstream
+closely; they merge each pyright release tag, usually same day). What it adds:
+
+- Packaging is solved. The build is `uv build` via a pdm-backend hook that
+  webpack-bundles the language server into the Python package. One
+  platform-independent wheel; Node comes from the `nodejs-wheel-binaries`
+  dependency. No per-platform builds.
+- The editor story is free. The stock basedpyright VS Code extension defaults
+  `importStrategy` to `fromEnvironment`, launching `basedpyright-langserver`
+  from the active venv. A forked wheel that keeps the module and entry-point
+  names gets picked up by the unmodified extension.
+- Their divergence from upstream shows this kind of patch is sustainable:
+  ~19k added lines across `pyright-internal/src`, carried through weekly
+  upstream merges by one maintainer. Our patch would be ~100-150 lines in two
+  source files (`typeEvaluator.ts` or `functionTransform.ts`, plus
+  `sourceFile.ts`) and rides along with their merges. Their
+  `typeEvaluatorBased.test.ts` plus `samples/based_*` dirs are the exact
+  pattern the tests would follow.
+
+A generic version is also worth considering: a config option mapping a
+dynamic-class factory's fullname to a generated module and a name template.
+Framed as data rather than a code-execution plugin API, it's the kind of
+thing that could plausibly land upstream in basedpyright itself, which would
+retire the fork. Their pipeline runs a mypy_primer-style diagnostic diff
+across many OSS projects on every PR, so a change like this is easy to prove
+harmless.
+
+## ty
+
+The best patch and the worst fork, at least today.
+
+The idiom for hard-coding library knowledge is a trio of enums matched by
+fully qualified location: `KnownModule` (`ty_module_resolver/src/module.rs`),
+`KnownClass` (`types/class/known.rs`), and `KnownFunction`
+(`types/function.rs`). All three already contain third-party entries for
+pydantic, and `types/dedicated/pydantic.rs` is over a thousand lines of
+hard-coded pydantic model synthesis shipped in core, always on. The precedent
+could not be stronger.
+
+The swap itself:
+
+- `infer_class_definition` (`types/infer/builder/class.rs`) is the insertion
+  point. It already does a full symbol swap for `class NamedTuple` in the
+  typing module, and it has the class name, file, and inferred base types in
+  scope.
+- Cross-module lookup exists: `resolve_module_confident` plus
+  `imported_symbol` compose into exactly the needed helper
+  (`known_module_symbol` in `place.rs` is a five-line template to copy).
+- Invalidation is free. Module resolution and symbol lookup are salsa-tracked
+  queries, so regenerating `pick_schema.py` automatically re-infers every
+  class that consulted it. No bookkeeping. This is notably better than the
+  mypy plugin, whose incremental-cache behavior around regenerated modules
+  has always been the flaky part.
+- Tests are markdown files with `# revealed:` assertions (mdtest), which
+  makes them trivial to write.
+
+Estimate: 150-300 lines across `module.rs`, `function.rs`, `place.rs`, and
+`class.rs`, plus an mdtest file. No new salsa queries needed.
+
+The problem is churn. ty is beta, versioned 0.0.x with breaking changes
+allowed between any two releases, and `ty_python_semantic` sees roughly eight
+commits a day, with class inference under active refactor. A fork means
+conflicts on most rebases until it stabilizes. Their stated direction of
+building library support directly into core means a well-specified
+"generated-module redirect" mechanism might be sellable upstream eventually,
+but that's a pitch, not a plan.
+
+## Verdict
+
+| | Patch | Fork burden | Distribution |
+| --- | --- | --- | --- |
+| pyright | ~150-300 lines | Weekly releases, tracked by you | Worst: Pylance is closed, no first-party wheel |
+| basedpyright | ~100-150 lines | They merge upstream for you | Best: one wheel, stock extension finds it in the venv |
+| ty | ~150-300 lines | Worst: pre-1.0, ~8 commits/day on the semantic crate | Fine: cargo build |
+
+Fork basedpyright if we want this soon. Revisit ty once it stabilizes; its
+salsa architecture genuinely fixes the invalidation problem and the patch is
+the cleanest of the three.


### PR DESCRIPTION
Research notes on what it would take to get the pick() symbol swap working outside mypy. None of the three checkers have a plugin system, so this looks at hard-coding the behavior in a fork.

The short version: the code is small everywhere (100-300 lines, with direct in-tree precedent in each codebase). Half the feature is already free, since pick() returns Any and all three checkers silently tolerate an Any base class. The real costs are fork maintenance and distribution, and those point at basedpyright: smallest patch, they track upstream pyright for us, the wheel builds in one command, and the stock VS Code extension picks up a forked binary from the venv unmodified.

ty is the more interesting long-term home. Its salsa architecture invalidates dependents of the regenerated pick_schema module automatically, which fixes the flakiest part of the mypy plugin. But it's pre-1.0 and the semantic crate moves too fast to fork comfortably today.

Also included: docs/codegen-transform.md, a draft of the generic pitch. Instead of asking for a plugin API, it proposes a dataclass_transform-style decorator: the library declares that calls to a factory resolve against a codegen'd module, and the checker just looks the symbol up, falling back to the declared return type when it's missing. Nothing reactivated-specific in it, on purpose.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)