### PR TITLE
Only run RPC schema generation when the RPC framework is in use

### DIFF
--- a/reactivated/__init__.py
+++ b/reactivated/__init__.py
@@ -1,6 +1,7 @@
 import abc
 import atexit
 import enum
+import importlib
 import inspect
 import os
 import signal
@@ -61,17 +62,51 @@ def generate(function: GenerateFunction) -> None:
     generate_callbacks.append(function)
 
 
+def _should_run_rpc_generations() -> bool:
+    """
+    The pydantic RPC generators are only needed once a project adopts the new
+    RPC framework. Gating on the framework's registries keeps legacy-only
+    projects (which may use legacy `Pick` in context processors, unsupported by
+    the RPC generator) from paying its cost or hitting its schema limitations.
+    """
+    if "REACTIVATED_SKIP_RPC_GENERATIONS" in os.environ:
+        return False
+
+    from .rpc.core import (
+        _router_registry,
+        manually_exported_registry,
+        picks_registry,
+    )
+    from .rpc.forms import form_registry
+    from .rpc.template import template_registry
+
+    return bool(
+        _router_registry
+        or template_registry
+        or picks_registry
+        or manually_exported_registry
+        or form_registry
+    )
+
+
 def run_generations(skip_cache: bool = False) -> None:
     if "REACTIVATED_SKIP_GENERATIONS" in os.environ:
         return
 
+    # Routers, forms, and picks may live in modules reached only through the URL
+    # tree. Importing the URLconf populates their registries before the gate is
+    # evaluated; a cold process run with --skip-checks never loads it otherwise,
+    # so the gate would wrongly see them empty and skip RPC generation.
+    importlib.import_module(settings.ROOT_URLCONF)
+
     for generate_callback in generate_callbacks:
         generate_callback(skip_cache)
 
-    from .rpc.core import generate_client_schema, generate_server_schema
+    if _should_run_rpc_generations():
+        from .rpc.core import generate_client_schema, generate_server_schema
 
-    generate_server_schema(skip_cache=skip_cache)
-    generate_client_schema(skip_cache=skip_cache)
+        generate_server_schema(skip_cache=skip_cache)
+        generate_client_schema(skip_cache=skip_cache)
 
     from .apps import generate_schema
 

--- a/reactivated/pick.py
+++ b/reactivated/pick.py
@@ -10,6 +10,8 @@ from django.apps import apps
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models.fields.reverse_related import ForeignObjectRel
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
 
 from .models import ComputedRelation
 from .serialization import ComputedField, FieldDescriptor, create_schema
@@ -251,6 +253,17 @@ class BasePickHolder:
     model_class: type[models.Model]
     module: ModuleType
     fields: list[str] = []
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        # Legacy Pick predates the pydantic RPC framework and has no native
+        # pydantic schema; degrade to `any` so a legacy Pick appearing in a
+        # context processor renders as `unknown` instead of crashing the new
+        # generator. Full-fidelity legacy typing still comes from the legacy
+        # generator via get_json_schema().
+        return core_schema.any_schema()
 
     @classmethod
     def get_name(cls: type[BasePickHolder]) -> str | None:

--- a/sample/server/apps/samples/gate_empty_urls.py
+++ b/sample/server/apps/samples/gate_empty_urls.py
@@ -1,0 +1,3 @@
+from django.urls import URLPattern, URLResolver
+
+urlpatterns: list[URLPattern | URLResolver] = []

--- a/sample/server/apps/samples/gate_router.py
+++ b/sample/server/apps/samples/gate_router.py
@@ -1,0 +1,8 @@
+from django.http import HttpRequest
+from django.urls import URLPattern, URLResolver
+
+from reactivated.rpc import Router
+
+router = Router(HttpRequest)
+
+urlpatterns: list[URLPattern | URLResolver] = []

--- a/sample/server/apps/samples/gate_urls.py
+++ b/sample/server/apps/samples/gate_urls.py
@@ -1,0 +1,5 @@
+from django.urls import include, path
+
+urlpatterns = [
+    path("gate/", include("sample.server.apps.samples.gate_router")),
+]

--- a/tests/rpc.py
+++ b/tests/rpc.py
@@ -15,20 +15,27 @@ from django.db import models as dj_models
 from django.http import HttpRequest
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
+import reactivated
+from reactivated.pick import Pick as LegacyPick
 from reactivated.rpc import FormField, Pick, Router, export, form
+from reactivated.rpc import context as rpc_context
 from reactivated.rpc.core import (
     PickAsDict,
     PickProxy,
     Primitive,
+    _router_registry,
     _type_to_str,
     form_from_type_adapter,
     generate_server_schema,
     get_field_schema,
     manually_exported_registry,
     pick,
+    picks_registry,
 )
-from reactivated.rpc.forms import get_form_schema
+from reactivated.rpc.forms import form_registry, get_form_schema
+from reactivated.rpc.template import template_registry
 from reactivated.rpc.utils import flatten_schema
+from sample.server.apps.samples import models
 
 
 def unique_email() -> str:
@@ -1150,3 +1157,164 @@ async def test_router_principal_injection(settings: Any, rf: Any) -> None:
     response = await rpc.handlers["rpc_with_request_and_form"]["handler"](request)
     assert response.status_code == 200
     assert json.loads(response.content) == "boss:POST:hi"
+
+
+class LegacyPickContext(TypedDict):
+    picked_continent: LegacyPick[models.Continent, Literal["name"]]
+
+
+def legacy_pick_context(request: HttpRequest) -> LegacyPickContext:
+    # Fixture: only its return annotation is read by get_context_class().
+    raise NotImplementedError
+
+
+@pytest.fixture
+def jsx_context_processors(settings: Any) -> Any:
+    def _register(paths: list[str]) -> None:
+        settings.TEMPLATES = [
+            {
+                "BACKEND": "reactivated.backend.JSX",
+                "DIRS": [],
+                "APP_DIRS": True,
+                "OPTIONS": {"context_processors": paths},
+            }
+        ]
+        rpc_context._context_processor_paths = None
+        rpc_context._context_processors = None
+
+    yield _register
+    rpc_context._context_processor_paths = None
+    rpc_context._context_processors = None
+
+
+def test_legacy_pick_in_context_processor_renders_unknown(
+    jsx_context_processors: Any,
+) -> None:
+    jsx_context_processors([f"{__name__}.legacy_pick_context"])
+
+    Context = rpc_context.get_context_class()
+    schema = Context.model_json_schema(mode="serialization")
+
+    field = schema["properties"]["picked_continent"]
+    # Legacy Pick degrades to any_schema(), which emits no type/constraints and
+    # renders as `unknown` in the generated client schema.
+    assert set(field) <= {"title"}
+
+
+_GATE_EMPTY_URLCONF = "sample.server.apps.samples.gate_empty_urls"
+_GATE_ROUTER_URLCONF = "sample.server.apps.samples.gate_urls"
+_GATE_ROUTER_MODULE = "sample.server.apps.samples.gate_router"
+
+
+@pytest.fixture
+def isolated_rpc_registries(monkeypatch: Any) -> Any:
+    saved_routers = list(_router_registry)
+    saved_templates = dict(template_registry)
+    saved_picks = list(picks_registry)
+    saved_exports = dict(manually_exported_registry)
+    saved_forms = list(form_registry)
+
+    _router_registry.clear()
+    template_registry.clear()
+    picks_registry.clear()
+    manually_exported_registry.clear()
+    form_registry.clear()
+
+    monkeypatch.setattr(reactivated, "generate_callbacks", [])
+    monkeypatch.delenv("REACTIVATED_SKIP_GENERATIONS", raising=False)
+    monkeypatch.delenv("REACTIVATED_SKIP_RPC_GENERATIONS", raising=False)
+
+    yield
+
+    _router_registry[:] = saved_routers
+    template_registry.clear()
+    template_registry.update(saved_templates)
+    picks_registry[:] = saved_picks
+    manually_exported_registry.clear()
+    manually_exported_registry.update(saved_exports)
+    form_registry[:] = saved_forms
+
+
+def _patch_generators(mocker: Any) -> tuple[Any, Any, Any]:
+    from reactivated import apps as reactivated_apps
+    from reactivated.rpc import core as rpc_core
+
+    return (
+        mocker.patch.object(rpc_core, "generate_server_schema"),
+        mocker.patch.object(rpc_core, "generate_client_schema"),
+        mocker.patch.object(reactivated_apps, "generate_schema"),
+    )
+
+
+def test_run_generations_skips_rpc_when_registries_empty(
+    isolated_rpc_registries: Any, mocker: Any, settings: Any
+) -> None:
+    settings.ROOT_URLCONF = _GATE_EMPTY_URLCONF
+    server, client, legacy = _patch_generators(mocker)
+
+    reactivated.run_generations()
+
+    server.assert_not_called()
+    client.assert_not_called()
+    legacy.assert_called_once()
+
+
+def test_run_generations_runs_rpc_when_registry_nonempty(
+    isolated_rpc_registries: Any, mocker: Any, settings: Any
+) -> None:
+    settings.ROOT_URLCONF = _GATE_EMPTY_URLCONF
+    Router(HttpRequest)
+    server, client, legacy = _patch_generators(mocker)
+
+    reactivated.run_generations()
+
+    server.assert_called_once()
+    client.assert_called_once()
+    legacy.assert_called_once()
+
+
+def test_run_generations_runs_rpc_when_form_only(
+    isolated_rpc_registries: Any, mocker: Any, settings: Any
+) -> None:
+    settings.ROOT_URLCONF = _GATE_EMPTY_URLCONF
+    form_registry.append(RequiredTestForm)
+    server, client, legacy = _patch_generators(mocker)
+
+    reactivated.run_generations()
+
+    server.assert_called_once()
+    client.assert_called_once()
+    legacy.assert_called_once()
+
+
+def test_run_generations_discovers_registrations_via_urlconf(
+    isolated_rpc_registries: Any, mocker: Any, settings: Any
+) -> None:
+    # Cold start: the router lives in a URL-included module that has not been
+    # imported yet (e.g. `generate_client_assets --skip-checks`, which never
+    # loads the URLconf). Importing it during generation must populate the gate.
+    sys.modules.pop(_GATE_ROUTER_URLCONF, None)
+    sys.modules.pop(_GATE_ROUTER_MODULE, None)
+    settings.ROOT_URLCONF = _GATE_ROUTER_URLCONF
+    server, client, legacy = _patch_generators(mocker)
+
+    reactivated.run_generations()
+
+    server.assert_called_once()
+    client.assert_called_once()
+    legacy.assert_called_once()
+
+
+def test_run_generations_rpc_skip_env(
+    isolated_rpc_registries: Any, mocker: Any, monkeypatch: Any, settings: Any
+) -> None:
+    settings.ROOT_URLCONF = _GATE_EMPTY_URLCONF
+    Router(HttpRequest)
+    monkeypatch.setenv("REACTIVATED_SKIP_RPC_GENERATIONS", "1")
+    server, client, legacy = _patch_generators(mocker)
+
+    reactivated.run_generations()
+
+    server.assert_not_called()
+    client.assert_not_called()
+    legacy.assert_called_once()


### PR DESCRIPTION
### Problem

Since 0.50.0, `run_generations()` runs the pydantic-based RPC schema generators unconditionally. A project that uses the long-standing legacy `Pick[...]` API in a context processor's return type crashes
at codegen: `generate_client_schema()` builds a pydantic model of the template context, and a legacy `Pick` resolves to `BasePickHolder`, which has no `__get_pydantic_core_schema__` — so
`model_json_schema()` raises `PydanticSchemaGenerationError`. This breaks codegen for legacy projects that have adopted **zero** RPCs.

### Fix

Two changes:

1. **Gate the RPC generators on actual usage.** `run_generations()` now runs `generate_server_schema` / `generate_client_schema` only when the RPC framework's registries are non-empty
(`_router_registry`, `template_registry`, `picks_registry`, `manually_exported_registry`, `form_registry`). Legacy-only projects skip them entirely and are unaffected. A new
`REACTIVATED_SKIP_RPC_GENERATIONS` env var skips only the RPC generators while leaving legacy generation running (the existing `REACTIVATED_SKIP_GENERATIONS` still skips everything).

2. **Degrade legacy `Pick` gracefully instead of crashing.** `BasePickHolder` gets a `__get_pydantic_core_schema__` returning `any_schema()`, so once a project *does* adopt RPC, a legacy `Pick` in the
template context renders as `unknown` in the generated client schema rather than aborting the whole pass. The legacy generator still emits full-fidelity types for it. This only affects the legacy
`reactivated.pick.BasePickHolder`; the RPC framework's own `Pick` (`reactivated.rpc.core`) is a separate class and is unchanged.

The URLconf is imported at the top of `run_generations()` before the gate is evaluated, so routers/forms/picks declared in modules reached only through the URL tree are registered before the check —
otherwise a cold process (`generate_client_assets --skip-checks`, which never loads the URLconf) would see empty registries and wrongly skip generation. The legacy path already imports the URLconf
downstream, so this only moves that import earlier.

### Tests

- Legacy `Pick` in a context processor now generates (field is `unknown`) instead of raising.
- Empty registries → both RPC generators skipped, no `client/schema.tsx` / `pick_schema` written, legacy generation still runs.
- `REACTIVATED_SKIP_RPC_GENERATIONS` skips only the RPC generators.
- Cold-start: a router reachable only via `include()` in the URLconf triggers generation (regression guard for the gate-ordering fix); a form-only project triggers generation via `form_registry`.