### PR TITLE
Add explicit ApiError for RPC 400s and harden the transport error path

### DIFF
--- a/packages/reactivated/src/rpc.test.tsx
+++ b/packages/reactivated/src/rpc.test.tsx
@@ -1,0 +1,131 @@
+// Run with: npm exec -- jiti packages/reactivated/src/rpc.test.tsx
+// jiti (a declared dependency) transpiles this .tsx; node's built-in test
+// runner is avoided because jiti rewrites the "node:test" specifier to a bare
+// "test" require, which does not resolve.
+import assert from "node:assert/strict";
+
+import {RequesterResult, defaultRequester} from "./rpc";
+
+type MockResponse = {
+    status: number;
+    json: () => Promise<unknown>;
+};
+
+const globals = globalThis as {
+    fetch: typeof fetch;
+    document?: {cookie: string};
+};
+const originalFetch = globals.fetch;
+
+// defaultRequester reads document.cookie for the CSRF token.
+globals.document = {cookie: "csrftoken=token"};
+
+const stubFetch = (response: MockResponse): void => {
+    globals.fetch = (async () => response) as unknown as typeof fetch;
+};
+
+const call = (): Promise<RequesterResult> =>
+    defaultRequester("/rpc/example/", null, "POST");
+
+const cases: Array<[string, () => Promise<void>]> = [
+    [
+        "200 -> success with parsed data",
+        async () => {
+            stubFetch({status: 200, json: async () => ({ok: true})});
+            const result = await call();
+            assert.equal(result.type, "success");
+            assert.deepEqual(result.type === "success" && result.data, {ok: true});
+        },
+    ],
+    [
+        "400 -> invalid with parsed errors",
+        async () => {
+            stubFetch({status: 400, json: async () => ["bad"]});
+            const result = await call();
+            assert.equal(result.type, "invalid");
+            assert.deepEqual(result.type === "invalid" && result.errors, ["bad"]);
+        },
+    ],
+    [
+        "401 -> unauthorized",
+        async () => {
+            stubFetch({status: 401, json: async () => ({error: "UNAUTHORIZED"})});
+            const result = await call();
+            assert.equal(result.type, "unauthorized");
+        },
+    ],
+    [
+        "403 with JSON -> denied, reason resolved (not a Promise)",
+        async () => {
+            stubFetch({status: 403, json: async () => ({detail: "nope"})});
+            const result = await call();
+            assert.equal(result.type, "denied");
+            if (result.type === "denied") {
+                assert.ok(!(result.reason instanceof Promise));
+                assert.deepEqual(result.reason, {detail: "nope"});
+            }
+        },
+    ],
+    [
+        "403 without JSON -> denied, reason null",
+        async () => {
+            stubFetch({
+                status: 403,
+                json: async () => {
+                    throw new SyntaxError("Unexpected end of JSON input");
+                },
+            });
+            const result = await call();
+            assert.equal(result.type, "denied");
+            if (result.type === "denied") {
+                assert.equal(result.reason, null);
+            }
+        },
+    ],
+    [
+        "500 -> exception carrying an Error mentioning the status",
+        async () => {
+            stubFetch({status: 500, json: async () => ({})});
+            const result = await call();
+            assert.equal(result.type, "exception");
+            if (result.type === "exception") {
+                assert.ok(result.exception instanceof Error);
+                assert.match((result.exception as Error).message, /500/);
+            }
+        },
+    ],
+    [
+        "thrown fetch error -> exception carrying the thrown error",
+        async () => {
+            const networkError = new TypeError("network down");
+            globals.fetch = (async () => {
+                throw networkError;
+            }) as unknown as typeof fetch;
+            const result = await call();
+            assert.equal(result.type, "exception");
+            assert.equal(result.type === "exception" && result.exception, networkError);
+        },
+    ],
+];
+
+const run = async (): Promise<void> => {
+    let failures = 0;
+    for (const [name, fn] of cases) {
+        try {
+            await fn();
+            console.log(`  ok   ${name}`);
+        } catch (error) {
+            failures += 1;
+            console.error(`  FAIL ${name}`);
+            console.error(error);
+        } finally {
+            globals.fetch = originalFetch;
+        }
+    }
+    console.log(
+        `\ndefaultRequester: ${cases.length - failures}/${cases.length} passed`,
+    );
+    process.exit(failures === 0 ? 0 : 1);
+};
+
+void run();

--- a/packages/reactivated/src/rpc.tsx
+++ b/packages/reactivated/src/rpc.tsx
@@ -75,18 +75,18 @@ export const defaultRequester: Requester = async (url, payload, method) => {
         } else if (response.status === 403) {
             return {
                 type: "denied",
-                reason: response.json(),
+                reason: await response.json().catch(() => null),
             };
         }
+
+        return {
+            type: "exception",
+            exception: new Error(`RPC request failed with status ${response.status}`),
+        };
     } catch (error) {
         return {
             type: "exception",
             exception: error,
         };
     }
-
-    return {
-        type: "exception",
-        exception: null,
-    };
 };

--- a/packages/reactivated/tsconfig.json
+++ b/packages/reactivated/tsconfig.json
@@ -14,5 +14,5 @@
         "skipLibCheck": true
     },
     "include": ["./**/*"],
-    "exclude": ["node_modules", "dist/"]
+    "exclude": ["node_modules", "dist/", "**/*.test.tsx"]
 }

--- a/packages/reactivated/tsconfig.test.json
+++ b/packages/reactivated/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true
+    },
+    "include": ["src/**/*.test.tsx"],
+    "exclude": ["node_modules", "dist/"]
+}

--- a/reactivated/rpc/__init__.py
+++ b/reactivated/rpc/__init__.py
@@ -1,4 +1,5 @@
 from .core import InlinePick, Pick, PickProxy, Router, anyone, export, pick
+from .errors import ApiError
 from .forms import FormField, form
 from .observer import RequestStatus, rpc_observer
 from .template import AdminChangeView, AdminListView, AdminView, Template
@@ -7,6 +8,7 @@ __all__ = [
     "AdminChangeView",
     "AdminListView",
     "AdminView",
+    "ApiError",
     "FormField",
     "InlinePick",
     "Pick",

--- a/reactivated/rpc/core.py
+++ b/reactivated/rpc/core.py
@@ -88,6 +88,7 @@ from reactivated.serialization.registry import Thing
 from reactivated.utils import ClassLookupDict
 from typing_extensions import ParamSpec
 
+from .errors import ApiError
 from .forms import FormField as FormField  # noqa: F401
 from .forms import form as form  # noqa: F401
 from .forms import generate_forms_export
@@ -445,6 +446,17 @@ class Router(Generic[TAnonymous]):
                                     return rpc_call(principal, **kwargs)
 
                             validated_model = await sync_wrapper()
+                    except ApiError as error:
+                        await _notify_observer(
+                            status=RequestStatus.INVALID,
+                            exception=error,
+                        )
+                        return get_response(
+                            input=None,
+                            content=error.messages,
+                            status_code=400,
+                            is_ui=False,
+                        )
                     except AssertionError as error:
                         await _notify_observer(
                             status=RequestStatus.INVALID,
@@ -562,6 +574,19 @@ class Router(Generic[TAnonymous]):
                                 )
 
                         validated_model = await sync_wrapper()
+                except ApiError as error:
+                    await _notify_observer(
+                        status=RequestStatus.INVALID,
+                        input=data,
+                        body=request.body,
+                        exception=error,
+                    )
+                    return get_response(
+                        input=data,
+                        content=error.messages,
+                        status_code=400,
+                        is_ui=is_ui,
+                    )
                 except AssertionError as error:
                     await _notify_observer(
                         status=RequestStatus.INVALID,

--- a/reactivated/rpc/errors.py
+++ b/reactivated/rpc/errors.py
@@ -1,0 +1,15 @@
+class ApiError(Exception):
+    """Raise from an RPC handler to signal invalid input to the client.
+
+    Explicit successor to the ``raise AssertionError(...)`` idiom, which is
+    stripped under ``python -O``. Always produces a 400 response whose body is
+    ``messages``, mirroring pydantic validation failures.
+
+    Non-400 business outcomes (e.g. "already submitted", "feature disabled")
+    are not errors: model them as discriminated success outputs — a 200 body
+    carrying a status field the client switches on — not HTTP error codes.
+    """
+
+    def __init__(self, *messages: str) -> None:
+        super().__init__(*messages)
+        self.messages: list[str] = list(messages)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -79,6 +79,8 @@ if [[ $CLIENT -eq 1 ]]; then
     # capture_stdout_and_stderr_if_successful node_modules/.bin/tslint -p packages/reactivated
     # capture_stdout_and_stderr_if_successful node_modules/.bin/tslint -p sample
     capture_stdout_and_stderr_if_successful npm exec -- prettier --ignore-path .gitignore --check '**/*.{ts,tsx,yaml,json}'
+    capture_stdout_and_stderr_if_successful npm exec -- tsc --noEmit -p packages/reactivated/tsconfig.test.json
+    capture_stdout_and_stderr_if_successful npm exec -- jiti packages/reactivated/src/rpc.test.tsx
 fi
 
 if [[ $E2E -eq 1 ]]; then

--- a/tests/rpc.py
+++ b/tests/rpc.py
@@ -15,7 +15,7 @@ from django.db import models as dj_models
 from django.http import HttpRequest
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
-from reactivated.rpc import FormField, Pick, Router, export, form
+from reactivated.rpc import ApiError, FormField, Pick, Router, export, form
 from reactivated.rpc.core import (
     PickAsDict,
     PickProxy,
@@ -656,6 +656,19 @@ async def test_sync_rpc_rolls_back_on_errors(rf: Any) -> None:
         User.objects.create(username=form[0], email=form[0])
         1 / 0
 
+    # ApiError must roll back too — atomic_requests defaults to True here.
+    @rpc(anyone)
+    def sync_api_error_form(request: HttpRequest, form: list[str]) -> None:
+        User.objects.create(username=form[0], email=form[0])
+        raise ApiError("invalid")
+
+    no_form_email = unique_email()
+
+    @rpc(anyone)
+    def sync_api_error_no_form(request: HttpRequest) -> None:
+        User.objects.create(username=no_form_email, email=no_form_email)
+        raise ApiError("invalid")
+
     generate_server_schema()
 
     expected_email = unique_email()
@@ -680,6 +693,29 @@ async def test_sync_rpc_rolls_back_on_errors(rf: Any) -> None:
     with pytest.raises(ZeroDivisionError):
         await rpc.handlers["rpc_sync_unexpected"]["handler"](request)
     assert not await sync_to_async(User.objects.filter(email=unexpected_email).exists)()
+
+    api_error_form_email = unique_email()
+    request = rf.post(
+        f"/{rpc.handlers['rpc_sync_api_error_form']['url']}",
+        data=json.dumps([api_error_form_email]),
+        content_type="application/json",
+    )
+    request.user = AnonymousUser()
+    response = await rpc.handlers["rpc_sync_api_error_form"]["handler"](request)
+    assert response.status_code == 400
+    assert not await sync_to_async(
+        User.objects.filter(email=api_error_form_email).exists
+    )()
+
+    request = rf.post(
+        f"/{rpc.handlers['rpc_sync_api_error_no_form']['url']}",
+        data="null",
+        content_type="application/json",
+    )
+    request.user = AnonymousUser()
+    response = await rpc.handlers["rpc_sync_api_error_no_form"]["handler"](request)
+    assert response.status_code == 400
+    assert not await sync_to_async(User.objects.filter(email=no_form_email).exists)()
 
 
 @pytest.mark.django_db
@@ -1086,6 +1122,85 @@ async def test_observer_notified(
 
     assert len(calls) == 1
     assert calls[0][0] == RequestStatus[expected_status]
+
+
+@pytest.mark.asyncio
+async def test_api_error_form_path(rf: Any) -> None:
+    from reactivated.rpc.observer import RequestStatus, rpc_observer
+
+    calls: list[RequestStatus] = []
+
+    @rpc_observer
+    async def observer(
+        request: Any,
+        rpc_name: str,
+        log: Any,
+        status: RequestStatus,
+        input: Any,
+        output: Any,
+        body: Any,
+        exception: BaseException | None,
+    ) -> None:
+        calls.append(status)
+
+    rpc = Router(HttpRequest)
+
+    @rpc(anyone, atomic_requests=False, log=True)
+    def raises_api_error(request: HttpRequest, form: list[str]) -> None:
+        raise ApiError("bad")
+
+    request = rf.post(
+        f"/{rpc.handlers['rpc_raises_api_error']['url']}",
+        data=json.dumps(["anything"]),
+        content_type="application/json",
+    )
+    request.user = AnonymousUser()
+    response = await rpc.handlers["rpc_raises_api_error"]["handler"](request)
+
+    assert response.status_code == 400
+    assert json.loads(response.content) == ["bad"]
+    assert calls == [RequestStatus.INVALID]
+
+
+@pytest.mark.asyncio
+async def test_api_error_no_form_path(rf: Any) -> None:
+    rpc = Router(HttpRequest)
+
+    @rpc(anyone, atomic_requests=False)
+    def raises_no_form(request: HttpRequest) -> None:
+        raise ApiError("nope")
+
+    request = rf.post(
+        f"/{rpc.handlers['rpc_raises_no_form']['url']}",
+        data="null",
+        content_type="application/json",
+    )
+    request.user = AnonymousUser()
+    response = await rpc.handlers["rpc_raises_no_form"]["handler"](request)
+
+    assert response.status_code == 400
+    assert json.loads(response.content) == ["nope"]
+
+
+@pytest.mark.asyncio
+async def test_assertion_error_still_returns_400(rf: Any) -> None:
+    """Back-compat: the legacy raise-AssertionError idiom keeps working."""
+    rpc = Router(HttpRequest)
+
+    @rpc(anyone, atomic_requests=False)
+    def raises_assertion(request: HttpRequest, form: list[str]) -> None:
+        raise AssertionError("bad")
+
+    request = rf.post(
+        f"/{rpc.handlers['rpc_raises_assertion']['url']}",
+        data=json.dumps(["anything"]),
+        content_type="application/json",
+    )
+    request.user = AnonymousUser()
+    response = await rpc.handlers["rpc_raises_assertion"]["handler"](request)
+
+    assert response.status_code == 400
+    assert json.loads(response.content) == ["bad"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### ApiError

RPC handlers currently signal a user-facing 400 by `raise AssertionError(...)`, which is stripped under `python -O`. This adds an explicit `reactivated.rpc.ApiError(*messages)` caught in both handler
paths immediately before the existing `except AssertionError` (kept for back-compat). At 400 the response body is byte-identical to the assertion idiom, and the observer is still notified `INVALID`.

`ApiError` is deliberately 400-only. Non-400 business outcomes ("already submitted", "feature disabled") are not errors and should be modeled as discriminated success outputs — a 200 body with a status
field the client switches on — rather than HTTP error codes, which the `RPCResult` transport doesn't surface bodies for anyway.

### Transport fixes (`packages/reactivated/src/rpc.tsx`)

- The 403 branch built `reason` from an **un-awaited** `response.json()`, so `denied` results carried a dangling Promise. Now `await response.json().catch(() => null)` (403 bodies aren't guaranteed
JSON).
- Unmatched statuses (405/409/5xx) fell through to `{type: "exception", exception: null}`, discarding all diagnostic signal. They now return `{type: "exception", exception: new Error(\`RPC request
failed with status N\`)}` — a real Error for Sentry — while thrown fetch errors still return the caught error.

### Tests

- Python: `ApiError("bad")` → 400 with body `["bad"]` + observer `INVALID`; the `AssertionError` idiom still returns 400 (regression); and direct rollback coverage — a handler that creates a row then
raises `ApiError` under `atomic_requests=True` leaves no row.
- TS: 7 `defaultRequester` cases (200/400/401/403-with-JSON/403-without-JSON/500/thrown) asserting the 403 `reason` is a resolved value (not a Promise) and non-matched statuses yield a non-null `Error`.
These are now **wired into `scripts/test.sh`** (run via `jiti`, already in the lockfile — no new dependency) and typechecked via a `noEmit` `tsconfig.test.json`; the production build still excludes
`*.test.tsx` from `dist/`.