### PR TITLE
Add nested scopes with built-in gates

### DIFF
--- a/reactivated/router.py
+++ b/reactivated/router.py
@@ -1,20 +1,38 @@
 """Typed view routing: scopes, derived URLs, and statically-checked views.
 
-The URL space is a tree. Params live only in Python signatures, never in
-strings. Three registration verbs on a Router instance (imported by
-urls.py — no autodiscovery, no global state):
+The URL space is a tree, and it is WRITTEN as a tree: a Scope is a router
+node, so children register on their parent, not on the router with a
+kwarg. Params live only in Python signatures, never in strings. The
+registration verbs (imported by urls.py — no autodiscovery, no global
+state):
 
-- ``@router.scope`` — a resolution edge. Consumes its keyword-only URL
-  kwargs, resolves objects once, returns a product (any value), an
+- ``@router.scope`` — a ROOT resolution edge. Consumes its keyword-only
+  URL kwargs, resolves objects once, returns a product (any value), an
   ``HttpResponse`` (rich failures stay responses), or ``False`` — the
   canonical denial: a login redirect with ``next``, the Django admin's
   semantics for unauthorized visitors.
-- ``@router.view(parent)`` — a worded page. Receives ``(primary, root?,
+- ``@parent_scope.scope`` — a child resolution edge. Same contract; its
+  first positional argument is the parent's product. Because the method
+  lives on the parent, the parent's product type binds directly into the
+  child-signature check, and cross-router parenting is unrepresentable.
+- ``@parent_scope.view`` — a worded page. Receives ``(primary, root?,
   request, *, url_params)`` and returns an ``HttpResponse`` or an
   ``rpc.Template``, which the chain renders. Post/redirect/get reads as
   ``templates.X | HttpResponse``.
-- ``@router.index(parent)`` — a wordless page at the parent's own URL.
+- ``@parent_scope.index`` — a wordless page at the parent's own URL.
   Same contract as ``view``; contributes no leaf word.
+
+There is no view-parenting: a registered view is, deliberately, the
+original plain function (direct calls are fully typed), so nothing hangs
+off it. Nesting under a page's URL is spelled with ``path=`` pins on
+siblings (``path="planner"`` for the page, ``path="planner/targets"``
+for the thing beneath it) — the word repeats, visibly, and a typo 404s
+instead of silently forking the URL space. A scope exists when its
+resolution is SHARED (a gate for a subtree, an object with several
+pages, an RPC access adapter); a lookup with a single consumer is just
+the first line of its page, promoted to a scope when the second consumer
+arrives. Scopes may carry both a pinned word and params
+(``@parent.scope(path="truth")`` with ``*, uuid`` -> ``truth/<uuid>/``).
 
 Like the RPC router, the decorators hand back the ORIGINAL FUNCTION:
 direct calls are fully typed, args and return — you pass what the
@@ -52,7 +70,9 @@ swallow bogus positional params. Request-last makes them a mypy error.
 import inspect
 import warnings
 from typing import (
+    TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
     Concatenate,
     Generic,
@@ -60,27 +80,41 @@ from typing import (
     ParamSpec,
     Protocol,
     TypeVar,
-    cast,
     get_args,
     get_origin,
     overload,
 )
 
+from asgiref.sync import async_to_sync
 from django.http import HttpRequest, HttpResponse
 from django.urls import path as django_path
 from django.urls.resolvers import URLPattern
 
 from .rpc.core import (
     RPC,
-    RPCAccess,
     RPCDecorator,
+    RPCInput,
+    RPCOutput,
     ScopeDenied,
     TAnonymous,
     TPrincipal,
+    anyone,
     build_rpc_decorator,
 )
 from .templates import Template
 from .transport import DJANGO_CONVERTERS, resolved_hints, url_segment
+
+if TYPE_CHECKING:
+    # `_User` is a django-stubs-only alias: the plugin rewrites it to the
+    # project's AUTH_USER_MODEL at the CONSUMER's mypy run (even across a
+    # py.typed boundary), so a framework-shipped `authenticated` scope injects
+    # the project's concrete User. It does NOT exist at runtime, hence the
+    # TYPE_CHECKING guard + string annotations; the built-in scopes below are
+    # hand-constructed so reactivated never resolves these hints at runtime.
+    # Older django-stubs lack `_User`; the ignore keeps reactivated's own
+    # checks green (it degrades to Any there), while consumers on modern stubs
+    # resolve their concrete User.
+    from django.contrib.auth.models import _User  # type: ignore[attr-defined]
 
 P = ParamSpec("P")
 Q = ParamSpec("Q")
@@ -89,10 +123,10 @@ TChild = TypeVar("TChild")
 TRoot = TypeVar("TRoot")
 R = TypeVar("R", bound="Template | HttpResponse")
 # Variance-marked flavors for the protocols (mypy requires exact variance):
-# primaries are inputs (contravariant), the phantom root and returns are
-# outputs (covariant); RootViewFn's root is both, so it stays invariant.
+# primaries and the root are inputs (contravariant), returns are outputs
+# (covariant).
 TValue_contra = TypeVar("TValue_contra", contravariant=True)
-TRoot_co = TypeVar("TRoot_co", covariant=True)
+TRoot_contra = TypeVar("TRoot_contra", contravariant=True)
 R_co = TypeVar("R_co", bound="Template | HttpResponse", covariant=True)
 
 # Used only for parent-name stemming: children of a view named
@@ -193,16 +227,166 @@ class _Node:
 
 
 class Scope(Generic[TValue, TRoot]):
-    """Typed handle for a resolution edge. TValue is what it resolves;
-    TRoot is the root scope's product, inherited down the whole chain."""
+    """Typed handle for a resolution edge — and a router node: children
+    (scopes, views, the index) register on it directly, which is what
+    makes trees read as trees, binds the parent product type into every
+    child-signature check, and leaves cross-router parenting with no
+    spelling. TValue is what it resolves; TRoot is the root scope's
+    product, inherited down the whole chain."""
 
     def __init__(
-        self, fn: Callable[..., object], node: _Node, takes_request: bool
+        self,
+        fn: Callable[..., object],
+        node: _Node,
+        takes_request: bool,
+        router: "Router[Any]",
     ) -> None:
         self.fn = fn
         self.name = fn.__name__
+        self.__module__ = fn.__module__
         self.node = node
         self.takes_request = takes_request
+        self.router = router
+
+    @overload
+    def scope(  # async child scope (with request) — matched first
+        self,
+        fn: Callable[
+            Concatenate[TValue, HttpRequest, Q],
+            "Awaitable[TChild | HttpResponse | Literal[False]]",
+        ],
+    ) -> "Scope[TChild, TRoot]": ...
+
+    @overload
+    def scope(  # async child scope (no request)
+        self,
+        fn: Callable[
+            Concatenate[TValue, Q], "Awaitable[TChild | HttpResponse | Literal[False]]"
+        ],
+    ) -> "Scope[TChild, TRoot]": ...
+
+    @overload
+    def scope(
+        self,
+        fn: Callable[
+            Concatenate[TValue, HttpRequest, Q],
+            "TChild | HttpResponse | Literal[False]",
+        ],
+    ) -> "Scope[TChild, TRoot]": ...
+
+    @overload
+    def scope(
+        self,
+        fn: Callable[Concatenate[TValue, Q], "TChild | HttpResponse | Literal[False]"],
+    ) -> "Scope[TChild, TRoot]": ...
+
+    @overload
+    def scope(self, fn: None = None, *, path: str) -> "ScopeBinder[TValue, TRoot]": ...
+
+    def scope(
+        self,
+        fn: "Callable[..., object] | None" = None,
+        *,
+        path: "str | None" = None,
+    ) -> object:
+        """A child resolution edge. Bare for the derived word (or
+        wordlessness, for param scopes); ``path=`` pins words, and
+        ``path=""`` declares a wordless refinement edge (a silent gate)."""
+        if fn is not None:
+            return _build_scope(fn, parent=self, path=None, router=self.router)
+        return ScopeBinder(self, path)
+
+    @overload
+    def view(  # type: ignore[overload-overlap]
+        self,
+        fn: Callable[Concatenate[TValue, TRoot, HttpRequest, P], R],
+    ) -> "RootViewFn[TValue, TRoot, P, R]": ...
+
+    @overload
+    def view(
+        self,
+        fn: Callable[Concatenate[TValue, HttpRequest, P], R],
+    ) -> "ViewFn[TValue, P, R]": ...
+
+    @overload
+    def view(self, fn: None = None, *, path: str) -> "ViewBinder[TValue, TRoot]": ...
+
+    def view(
+        self,
+        fn: "Callable[..., Any] | None" = None,
+        *,
+        path: "str | None" = None,
+    ) -> Any:
+        """A worded page under this scope. Bare for the derived leaf word
+        (name minus this scope's prefix, snake -> kebab); ``path=`` pins."""
+        binder: ViewBinder[TValue, TRoot] = ViewBinder(
+            self.router, self.name, self.node, path
+        )
+        if fn is not None:
+            return binder(fn)
+        return binder
+
+    @overload
+    def index(  # type: ignore[overload-overlap]
+        self,
+        fn: Callable[Concatenate[TValue, TRoot, HttpRequest, P], R],
+    ) -> "RootViewFn[TValue, TRoot, P, R]": ...
+
+    @overload
+    def index(
+        self,
+        fn: Callable[Concatenate[TValue, HttpRequest, P], R],
+    ) -> "ViewFn[TValue, P, R]": ...
+
+    def index(self, fn: Callable[..., Any]) -> Any:
+        """The wordless page at this scope's own URL. Takes no ``path=``
+        by construction — forgetting a word is a signature fact, not a
+        check."""
+        binder: ViewBinder[TValue, TRoot] = ViewBinder(
+            self.router, self.name, self.node, None, is_index=True
+        )
+        return binder(fn)
+
+    @overload
+    def rpc(
+        self,
+        fn: Callable[Concatenate[TValue, RPCInput], RPCOutput],
+    ) -> Callable[Concatenate[TValue, RPCInput], RPCOutput]: ...
+
+    @overload
+    def rpc(
+        self,
+        fn: None = None,
+        *,
+        csrf_exempt: bool = False,
+        log: "Literal['errors'] | bool" = False,
+        atomic_requests: bool = True,
+        methods: "list[Literal['GET', 'POST']] | None" = None,
+    ) -> "RPCDecorator[TValue]": ...
+
+    def rpc(
+        self,
+        fn: "Callable[..., Any] | None" = None,
+        *,
+        csrf_exempt: bool = False,
+        log: "Literal['errors'] | bool" = False,
+        atomic_requests: bool = True,
+        methods: "list[Literal['GET', 'POST']] | None" = None,
+    ) -> Any:
+        """A procedure on this scope: the chain resolves + gates, its product
+        is injected as the handler's first arg (the principal), and a scope
+        failure coerces to a JSON 401. Sugar for ``@router.rpc(scope)`` — the
+        chain's params become URL segments, exactly as on a view."""
+        decorator = self.router.rpc(
+            self,
+            csrf_exempt=csrf_exempt,
+            log=log,
+            atomic_requests=atomic_requests,
+            methods=methods,
+        )
+        if fn is not None:
+            return decorator(fn)
+        return decorator
 
 
 class View:
@@ -233,10 +417,15 @@ class View:
         for index, entry in enumerate(self.node.scope_chain()):
             scope_kwargs = {name: kwargs.pop(name) for name in entry.params}
             assert entry.scope_fn is not None
+            fn = (
+                async_to_sync(entry.scope_fn)
+                if inspect.iscoroutinefunction(entry.scope_fn)
+                else entry.scope_fn
+            )
             if entry.scope_takes_request:
-                result = entry.scope_fn(product, request, **scope_kwargs)
+                result = fn(product, request, **scope_kwargs)
             else:
-                result = entry.scope_fn(product, **scope_kwargs)
+                result = fn(product, **scope_kwargs)
             if result is False:
                 return _deny(request)
             if result is True:
@@ -270,6 +459,7 @@ def _build_scope(
     fn: Callable[..., object],
     parent: "Scope[Any, Any] | None",
     path: "str | None",
+    router: "Router[Any]",
 ) -> "Scope[Any, Any]":
     params = _url_params(fn)
     if path is not None:
@@ -303,11 +493,36 @@ def _build_scope(
         scope_fn=fn,
         scope_takes_request=takes_request,
     )
-    return Scope(fn, node, takes_request)
+    return Scope(fn, node, takes_request, router)
+
+
+class RootScopeBinder:
+    """Binder for ``@router.scope(path="...")``: a ROOT scope whose URL
+    word comes from ``path`` instead of the function name — the way two
+    subtrees share a word (a public tree and a principal-rooted staff tree
+    both under ``annotate/``). The product doubles as the root product,
+    exactly like the bare ``@router.scope`` form."""
+
+    def __init__(self, path: "str | None", router: "Router[Any]") -> None:
+        self._path = path
+        self._router = router
+
+    def __call__(
+        self,
+        fn: Callable[
+            Concatenate[HttpRequest, Q], "TChild | HttpResponse | Literal[False]"
+        ],
+    ) -> Scope[TChild, TChild]:
+        return _build_scope(fn, parent=None, path=self._path, router=self._router)
 
 
 class ScopeBinder(Generic[TValue, TRoot]):
-    def __init__(self, parent: "Scope[Any, Any] | None", path: "str | None") -> None:
+    """Binder for ``@parent_scope.scope(path="...")`` — the parametrized
+    child form. The parent is always a Scope: root path-pinning is
+    ``RootScopeBinder``, and parenting is spelled on the parent, never as
+    a router kwarg."""
+
+    def __init__(self, parent: "Scope[Any, Any]", path: "str | None") -> None:
         self._parent = parent
         self._path = path
 
@@ -327,14 +542,14 @@ class ScopeBinder(Generic[TValue, TRoot]):
     ) -> Scope[TChild, TRoot]: ...
 
     def __call__(self, fn: Callable[..., object]) -> "Scope[Any, Any]":
-        return _build_scope(fn, parent=self._parent, path=self._path)
+        return _build_scope(
+            fn, parent=self._parent, path=self._path, router=self._parent.router
+        )
 
 
-class ViewFn(Protocol[TValue_contra, TRoot_co, P, R_co]):
+class ViewFn(Protocol[TValue_contra, P, R_co]):
     """The static face of a registered ``(primary, request)`` view. At
-    runtime it IS the original function — direct calls are fully typed.
-    ``TRoot`` rides as a phantom so view-parenting can always recover it,
-    even though a 2-arity signature never mentions the root."""
+    runtime it IS the original function — direct calls are fully typed."""
 
     __name__: str
 
@@ -347,11 +562,8 @@ class ViewFn(Protocol[TValue_contra, TRoot_co, P, R_co]):
         **kwargs: P.kwargs,
     ) -> R_co: ...
 
-    @property
-    def __view_root__(self) -> TRoot_co: ...  # phantom: never exists at runtime
 
-
-class RootViewFn(Protocol[TValue_contra, TRoot, P, R_co]):
+class RootViewFn(Protocol[TValue_contra, TRoot_contra, P, R_co]):
     """As ``ViewFn`` for ``(primary, root, request)`` views."""
 
     __name__: str
@@ -359,29 +571,12 @@ class RootViewFn(Protocol[TValue_contra, TRoot, P, R_co]):
     def __call__(
         self,
         primary: TValue_contra,
-        root: TRoot,
+        root: TRoot_contra,
         request: HttpRequest,
         /,
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> R_co: ...
-
-    @property
-    def __view_root__(self) -> TRoot: ...
-
-
-class RegisteredView(Protocol[TValue_contra, TRoot_co]):
-    """What ``view(parent=...)`` needs from a view used as a parent: just
-    the phantoms. Both ``ViewFn`` and ``RootViewFn`` satisfy it."""
-
-    __name__: str
-
-    def __call__(
-        self, primary: TValue_contra, /, *args: Any, **kwargs: Any
-    ) -> object: ...
-
-    @property
-    def __view_root__(self) -> TRoot_co: ...
 
 
 class ViewBinder(Generic[TValue, TRoot]):
@@ -409,7 +604,7 @@ class ViewBinder(Generic[TValue, TRoot]):
     def __call__(
         self,
         fn: Callable[Concatenate[TValue, HttpRequest, P], R],
-    ) -> "ViewFn[TValue, TRoot, P, R]": ...
+    ) -> "ViewFn[TValue, P, R]": ...
 
     def __call__(self, fn: Callable[..., Any]) -> Any:
         name = fn.__name__
@@ -464,7 +659,6 @@ class ViewBinder(Generic[TValue, TRoot]):
         node = _Node(self._parent_node, words, own_params, scope_fn=None)
         view = View(fn, node, takes_root=arity == 3)
         self._router._register_view(view)
-        self._router._known_nodes[fn] = node
         # The RPC pattern: hand back the original function, untouched.
         # Direct calls are just calls; the chain lives behind endpoint().
         return fn
@@ -482,16 +676,28 @@ class _ScopeAdapter:
             for entry in scope.node.scope_chain()
             for name, annotation in entry.params.items()
         ]
+        self.has_async: bool = any(
+            entry.scope_fn is not None and inspect.iscoroutinefunction(entry.scope_fn)
+            for entry in scope.node.scope_chain()
+        )
 
     def run(self, request: HttpRequest, kwargs: dict[str, Any]) -> Any:
+        """Resolve the chain synchronously. Async scope functions are bounced
+        through ``async_to_sync`` — so under an atomic request their ORM work
+        re-joins the transaction thread (see the rpc execution matrix)."""
         product: object = request
         for entry in self.scope.node.scope_chain():
             entry_kwargs = {name: kwargs.pop(name) for name in entry.params}
             assert entry.scope_fn is not None
+            fn = (
+                async_to_sync(entry.scope_fn)
+                if inspect.iscoroutinefunction(entry.scope_fn)
+                else entry.scope_fn
+            )
             if entry.scope_takes_request:
-                result = entry.scope_fn(product, request, **entry_kwargs)
+                result = fn(product, request, **entry_kwargs)
             else:
-                result = entry.scope_fn(product, **entry_kwargs)
+                result = fn(product, **entry_kwargs)
             if result is False or isinstance(result, HttpResponse):
                 return ScopeDenied(result)
             if result is True:
@@ -501,6 +707,20 @@ class _ScopeAdapter:
                 )
             product = result
         return product
+
+
+def _authenticated(request: HttpRequest) -> "_User | Literal[False]":
+    """Built-in gate: the authenticated user, or the canonical denial. Its
+    product types as the project's AUTH_USER_MODEL (see ``_User``)."""
+    user = request.user
+    return user if user.is_authenticated else False
+
+
+def _maybe_authenticated(request: HttpRequest) -> "_User | None":
+    """Built-in soft gate: the user if authenticated, else ``None`` — never
+    denies. Product is ``User | None``."""
+    user = request.user
+    return user if user.is_authenticated else None
 
 
 class Router(Generic[TAnonymous]):
@@ -519,12 +739,44 @@ class Router(Generic[TAnonymous]):
         self.request_type = request_type
         self.handlers: dict[str, RPC] = {}
         self._views: list[View] = []
-        self._known_nodes: dict[Callable[..., object], _Node] = {}
+        self._builtin_scopes: dict[str, Scope[Any, Any]] = {}
+
+    # -- built-in gates ------------------------------------------------------
+
+    def _builtin(self, word: str, fn: Callable[..., object]) -> "Scope[Any, Any]":
+        """A cached, hand-constructed root scope (no ``_url_params``/hint
+        resolution, so the ``_User`` annotations never evaluate at runtime).
+        Returned by identity so every use registers on one scope."""
+        scope = self._builtin_scopes.get(word)
+        if scope is None:
+            node = _Node(None, [word], {}, scope_fn=fn, scope_takes_request=False)
+            scope = Scope(fn, node, takes_request=False, router=self)
+            self._builtin_scopes[word] = scope
+        return scope
+
+    @property
+    def authenticated(self) -> "Scope[_User, _User]":
+        """Built-in ``authenticated`` gate. Injects the project's concrete
+        ``User`` (via django-stubs). Use as ``@router.authenticated.rpc`` /
+        ``@router.authenticated.view`` — the batteries replacement for an
+        ``authenticated`` access function."""
+        return self._builtin("authenticated", _authenticated)
+
+    @property
+    def maybe_authenticated(self) -> "Scope[_User | None, _User | None]":
+        """Built-in soft gate: injects ``User | None``, never denies."""
+        return self._builtin("maybe_authenticated", _maybe_authenticated)
 
     # -- procedures ----------------------------------------------------------
 
     @overload
-    def rpc(
+    def rpc(  # bare @router.rpc — public; the request is the principal
+        self,
+        access: Callable[Concatenate[TAnonymous, RPCInput], RPCOutput],
+    ) -> Callable[Concatenate[TAnonymous, RPCInput], RPCOutput]: ...
+
+    @overload
+    def rpc(  # @router.rpc(scope) — gated; the scope product is the principal
         self,
         access: "Scope[TPrincipal, Any]",
         *,
@@ -535,39 +787,58 @@ class Router(Generic[TAnonymous]):
     ) -> RPCDecorator[TPrincipal]: ...
 
     @overload
-    def rpc(
+    def rpc(  # @router.rpc() / @router.rpc(csrf_exempt=...) — public, with options
         self,
-        access: RPCAccess[TAnonymous, TPrincipal],
+        access: None = None,
         *,
         csrf_exempt: bool = False,
         log: "Literal['errors'] | bool" = False,
         atomic_requests: bool = True,
         methods: "list[Literal['GET', 'POST']] | None" = None,
-    ) -> RPCDecorator[TPrincipal]: ...
+    ) -> RPCDecorator[TAnonymous]: ...
 
     def rpc(
         self,
-        access: Any,
+        access: Any = None,
         *,
         csrf_exempt: bool = False,
         log: "Literal['errors'] | bool" = False,
         atomic_requests: bool = True,
         methods: "list[Literal['GET', 'POST']] | None" = None,
-    ) -> RPCDecorator[Any]:
-        scope_adapter = _ScopeAdapter(access) if isinstance(access, Scope) else None
-        return build_rpc_decorator(
+    ) -> Any:
+        if isinstance(access, Scope):
+            return build_rpc_decorator(
+                self.handlers,
+                scope_adapter=_ScopeAdapter(access),
+                access=None,
+                csrf_exempt=csrf_exempt,
+                log=log,
+                atomic_requests=atomic_requests,
+                is_query=False,
+                methods=methods,
+            )
+        # Public: the request itself is the principal (the identity gate).
+        decorator = build_rpc_decorator(
             self.handlers,
-            scope_adapter=scope_adapter,
-            access=None if scope_adapter else access,
+            scope_adapter=None,
+            access=anyone,
             csrf_exempt=csrf_exempt,
             log=log,
             atomic_requests=atomic_requests,
             is_query=False,
             methods=methods,
         )
+        # Bare @router.rpc: `access` is actually the handler — register it now.
+        return decorator if access is None else decorator(access)
 
     @overload
-    def query(
+    def query(  # bare @router.query — public; the request is the principal
+        self,
+        access: Callable[Concatenate[TAnonymous, RPCInput], RPCOutput],
+    ) -> Callable[Concatenate[TAnonymous, RPCInput], RPCOutput]: ...
+
+    @overload
+    def query(  # @router.query(scope)
         self,
         access: "Scope[TPrincipal, Any]",
         *,
@@ -576,46 +847,44 @@ class Router(Generic[TAnonymous]):
     ) -> RPCDecorator[TPrincipal]: ...
 
     @overload
-    def query(
+    def query(  # @router.query() / @router.query(csrf_exempt=...) — public
         self,
-        access: RPCAccess[TAnonymous, TPrincipal],
+        access: None = None,
         *,
         csrf_exempt: bool = False,
         log: "Literal['errors'] | bool" = False,
-    ) -> RPCDecorator[TPrincipal]: ...
+    ) -> RPCDecorator[TAnonymous]: ...
 
     def query(
         self,
-        access: Any,
+        access: Any = None,
         *,
         csrf_exempt: bool = False,
         log: "Literal['errors'] | bool" = False,
-    ) -> RPCDecorator[Any]:
-        scope_adapter = _ScopeAdapter(access) if isinstance(access, Scope) else None
-        return build_rpc_decorator(
+    ) -> Any:
+        if isinstance(access, Scope):
+            return build_rpc_decorator(
+                self.handlers,
+                scope_adapter=_ScopeAdapter(access),
+                access=None,
+                csrf_exempt=csrf_exempt,
+                log=log,
+                atomic_requests=False,
+                is_query=True,
+            )
+        decorator = build_rpc_decorator(
             self.handlers,
-            scope_adapter=scope_adapter,
-            access=None if scope_adapter else access,
+            scope_adapter=None,
+            access=anyone,
             csrf_exempt=csrf_exempt,
             log=log,
             atomic_requests=False,
             is_query=True,
         )
+        return decorator if access is None else decorator(access)
 
     def _register_view(self, view: View) -> None:
         self._views.append(view)
-
-    def _parent_info(self, parent: object) -> tuple[str, _Node]:
-        if isinstance(parent, Scope):
-            return parent.name, parent.node
-        fn = cast("Callable[..., object]", parent)
-        node = self._known_nodes.get(fn)
-        if node is None:
-            raise TypeError(
-                f"routing: {getattr(parent, '__name__', parent)!r} is not a "
-                f"scope or a view registered on this router"
-            )
-        return fn.__name__, node
 
     def endpoint(self, fn: Callable[..., object]) -> Callable[..., HttpResponse]:
         """The chain-running Django callable for a registered view — what
@@ -629,14 +898,20 @@ class Router(Generic[TAnonymous]):
     # -- scope ---------------------------------------------------------------
 
     @overload
+    def scope(  # async root scope — matched first (unwraps the Awaitable)
+        self,
+        fn: Callable[
+            Concatenate[HttpRequest, Q],
+            "Awaitable[TValue | HttpResponse | Literal[False]]",
+        ],
+    ) -> Scope[TValue, TValue]: ...
+
+    @overload
     def scope(
         self,
         fn: Callable[
             Concatenate[HttpRequest, Q], "TValue | HttpResponse | Literal[False]"
         ],
-        *,
-        parent: None = None,
-        path: "str | None" = None,
     ) -> Scope[TValue, TValue]: ...
 
     @overload
@@ -644,40 +919,21 @@ class Router(Generic[TAnonymous]):
         self,
         fn: None = None,
         *,
-        parent: Scope[TValue, TRoot],
-        path: "str | None" = None,
-    ) -> "ScopeBinder[TValue, TRoot]": ...
+        path: str,
+    ) -> "RootScopeBinder": ...
 
     def scope(
         self,
         fn: "Callable[..., object] | None" = None,
         *,
-        parent: "Scope[Any, Any] | None" = None,
         path: "str | None" = None,
     ) -> object:
+        """A ROOT scope. Children register on the returned Scope
+        (``@parent.scope`` / ``@parent.view`` / ``@parent.index``) — the
+        router itself only ever plants roots."""
         if fn is not None:
-            return _build_scope(fn, parent=None, path=path)
-        return ScopeBinder(parent, path)
-
-    # -- view ----------------------------------------------------------------
-
-    def view(
-        self,
-        parent: "Scope[TValue, TRoot] | RegisteredView[TValue, TRoot]",
-        *,
-        path: "str | None" = None,
-    ) -> ViewBinder[TValue, TRoot]:
-        name, node = self._parent_info(parent)
-        return ViewBinder(self, name, node, path)
-
-    def index(
-        self,
-        parent: "Scope[TValue, TRoot] | RegisteredView[TValue, TRoot]",
-    ) -> ViewBinder[TValue, TRoot]:
-        """A wordless page at the parent's own URL. Takes no ``path=`` by
-        construction — forgetting a word is a signature fact, not a check."""
-        name, node = self._parent_info(parent)
-        return ViewBinder(self, name, node, None, is_index=True)
+            return _build_scope(fn, parent=None, path=path, router=self)
+        return RootScopeBinder(path, self)
 
     # -- emission ------------------------------------------------------------
 
@@ -722,6 +978,21 @@ class Router(Generic[TAnonymous]):
             if name in by_name:
                 patterns.append(django_path(route, by_name[name], name=name))
         return patterns
+
+    def contributing_modules(self) -> set[str]:
+        """The modules that registered scopes, views, or rpcs on this router —
+        the provenance ``mount()`` verifies so a listed-but-empty module is a
+        boot error. rpcs and views record their defining module directly;
+        scopes are picked up from the chains of the views under them."""
+        modules: set[str] = set()
+        for rpc_call in self.handlers.values():
+            modules.add(rpc_call["module"])
+        for view in self._views:
+            modules.add(view.__module__)
+            for node in view.node.scope_chain():
+                if node.scope_fn is not None:
+                    modules.add(node.scope_fn.__module__)
+        return modules
 
     def _warn_untrimmable(self, routes: dict[str, str]) -> None:
         for view in self._views:

--- a/reactivated/transport.py
+++ b/reactivated/transport.py
@@ -14,6 +14,7 @@ all of them. Per-router checks cannot see a views router and an RPC router
 claiming the same name; ``mount()`` can.
 """
 
+import types
 import uuid
 from typing import Any, Callable, Protocol, get_type_hints, runtime_checkable
 
@@ -49,17 +50,43 @@ class Mountable(Protocol):
 mounted_routers: list[Mountable] = []
 
 
-def mount(*routers: Mountable) -> list[URLPattern]:
+def mount(*items: "Mountable | types.ModuleType") -> list[URLPattern]:
     """Emit every router's patterns with *global* duplicate detection.
 
-    Routes and reverse names must be unique across everything mounted —
-    pages and procedures alike. A conflict is a boot error here, instead of
-    Django silently first-matching the route and last-matching the name.
-    """
-    for router in routers:
-        if not isinstance(router, Mountable):
-            raise TypeError(f"mount: not a Mountable: {router!r}")
+    Each argument is either a router or — the idiomatic form — an imported
+    module that owns one (``mount(server.crm.annotations, ...)``). A module is
+    resolved to its ``router`` attribute and **verified**: it must have
+    registered at least one scope or route on that router, so a renamed or
+    empty module is a boot error naming it, not a silently missing page. A
+    shared-tree module that re-exports the spine's router (``router =
+    scopes.router``) is fine — routers dedupe by identity, so passing the same
+    one N times mounts it once.
 
+    Routes and reverse names must be unique across everything mounted — pages
+    and procedures alike. A conflict is a boot error here, instead of Django
+    silently first-matching the route and last-matching the name.
+    """
+    resolved: dict[int, Mountable] = {}
+    for item in items:
+        if isinstance(item, types.ModuleType):
+            router = getattr(item, "router", None)
+            if not isinstance(router, Mountable):
+                raise TypeError(
+                    f"mount: module {item.__name__!r} has no `router` to mount"
+                )
+            contributing = getattr(router, "contributing_modules", None)
+            if contributing is not None and item.__name__ not in contributing():
+                raise TypeError(
+                    f"mount: {item.__name__!r} registered no scopes or routes on its "
+                    f"router — missing a decorator, or the wrong module?"
+                )
+            resolved.setdefault(id(router), router)
+        elif isinstance(item, Mountable):
+            resolved.setdefault(id(item), item)
+        else:
+            raise TypeError(f"mount: not a module or Mountable: {item!r}")
+
+    routers = list(resolved.values())
     seen_routes: dict[str, str] = {}
     seen_names: dict[str, str] = {}
     patterns: list[URLPattern] = []

--- a/reactivated/views/router.py
+++ b/reactivated/views/router.py
@@ -294,6 +294,25 @@ def _build_scope(
     return Scope(fn, node, takes_request)
 
 
+class RootScopeBinder:
+    """Binder for ``@router.scope(path="...")`` with no parent: a ROOT scope
+    whose URL word comes from ``path`` instead of the function name — the
+    way two subtrees share a word (a public tree and a principal-rooted
+    staff tree both under ``annotate/``). The product doubles as the root
+    product, exactly like the bare ``@router.scope`` form."""
+
+    def __init__(self, path: "str | None") -> None:
+        self._path = path
+
+    def __call__(
+        self,
+        fn: Callable[
+            Concatenate[HttpRequest, Q], "TChild | HttpResponse | Literal[False]"
+        ],
+    ) -> Scope[TChild, TChild]:
+        return _build_scope(fn, parent=None, path=self._path)
+
+
 class ScopeBinder(Generic[TValue, TRoot]):
     def __init__(self, parent: "Scope[Any, Any] | None", path: "str | None") -> None:
         self._parent = parent
@@ -513,6 +532,15 @@ class Router:
         path: "str | None" = None,
     ) -> "ScopeBinder[TValue, TRoot]": ...
 
+    @overload
+    def scope(
+        self,
+        fn: None = None,
+        *,
+        parent: None = None,
+        path: str,
+    ) -> "RootScopeBinder": ...
+
     def scope(
         self,
         fn: "Callable[..., object] | None" = None,
@@ -522,6 +550,8 @@ class Router:
     ) -> object:
         if fn is not None:
             return _build_scope(fn, parent=None, path=path)
+        if parent is None:
+            return RootScopeBinder(path)
         return ScopeBinder(parent, path)
 
     # -- view ----------------------------------------------------------------

--- a/tests/rpc.py
+++ b/tests/rpc.py
@@ -38,10 +38,6 @@ def unique_email() -> str:
     return f"test-{uuid.uuid4().hex[:8]}@example.com"
 
 
-async def anyone(request: HttpRequest) -> HttpRequest:
-    return request
-
-
 class PrincipalEchoForm(Pick):
     """Module-level so get_type_hints can resolve it."""
 
@@ -213,15 +209,15 @@ def test_schema_generation_with_rpc_and_picks(settings: Any, tmp_path: Any) -> N
     settings.REACTIVATED_SERVER_SCHEMA = str(schema_dir)
     sys.path.insert(0, str(schema_dir))
 
-    @router.rpc(anyone)
+    @router.rpc
     def rpc_call(request: HttpRequest, form: int | str | list[str]) -> None:
         pass
 
-    @router.rpc(anyone)
+    @router.rpc
     def with_model(request: HttpRequest, form: MyModel) -> None:
         pass
 
-    @router.rpc(anyone)
+    @router.rpc
     def with_pick(request: HttpRequest, form: MyPick.input) -> None:
         pass
 
@@ -431,11 +427,11 @@ async def test_get_method_handling(settings: Any, rf: Any) -> None:
 
     # No form param — tests pure HTTP method handling.
     # (int/str are DJANGO_CONVERTERS so they become URL path params, not body forms.)
-    @router.rpc(anyone, atomic_requests=False)
+    @router.rpc(atomic_requests=False)
     def post_only(request: HttpRequest) -> None:
         pass
 
-    @router.rpc(anyone, methods=["GET", "POST"], atomic_requests=False)
+    @router.rpc(methods=["GET", "POST"], atomic_requests=False)
     def get_allowed(request: HttpRequest) -> None:
         pass
 
@@ -462,7 +458,7 @@ async def test_get_method_handling(settings: Any, rf: Any) -> None:
     # declared by omitting the param entirely (as post_only above does).
     with pytest.raises(TypeError, match="None-typed param"):
 
-        @router.rpc(anyone, atomic_requests=False)
+        @router.rpc(atomic_requests=False)
         def none_body(request: HttpRequest, form: None) -> None:
             pass
 
@@ -471,22 +467,23 @@ async def test_get_method_handling(settings: Any, rf: Any) -> None:
 async def test_router_authentication(settings: Any, rf: Any) -> None:
     settings.DEBUG = False
 
-    async def authentication(request: HttpRequest) -> HttpRequest | Literal[False]:
+    router = Router(HttpRequest)
+
+    @router.scope
+    def authentication(request: HttpRequest) -> "HttpRequest | Literal[False]":
         if isinstance(request.user, AnonymousUser):
             return False
         return request
 
-    router = Router(HttpRequest)
-
-    @router.rpc(authentication, atomic_requests=False)
+    @authentication.rpc(atomic_requests=False)
     def guarded(request: HttpRequest) -> str:
         return request.user.username
 
-    @router.rpc(authentication, atomic_requests=False)
+    @authentication.rpc(atomic_requests=False)
     async def async_guarded(request: HttpRequest) -> str:
         return request.user.username
 
-    @router.rpc(anyone, atomic_requests=False)
+    @router.rpc(atomic_requests=False)
     def open_to_all(request: HttpRequest) -> str:
         return "anyone"
 
@@ -532,7 +529,7 @@ async def test_router_authentication(settings: Any, rf: Any) -> None:
 async def test_form_required_validation(rf: Any) -> None:
     router = Router(HttpRequest)
 
-    @router.rpc(anyone, atomic_requests=False)
+    @router.rpc(atomic_requests=False)
     def required_test(request: Any, form: RequiredTestForm) -> str:
         return "ok"
 
@@ -626,7 +623,7 @@ async def test_form_required_validation(rf: Any) -> None:
     assert response.status_code == 200
 
     # Read-only fields are set to None regardless of client input
-    @router.rpc(anyone, atomic_requests=False)
+    @router.rpc(atomic_requests=False)
     def read_only_test(request: Any, form: ReadOnlyTestForm) -> str:
         assert form.editable == "value"
         assert form.read_only_field is None
@@ -649,12 +646,12 @@ async def test_sync_rpc_rolls_back_on_errors(rf: Any) -> None:
     router = Router(HttpRequest)
 
     # Use list[str] because bare str is a DJANGO_CONVERTER (URL path param).
-    @router.rpc(anyone)
+    @router.rpc
     def sync_expected(request: HttpRequest, form: list[str]) -> None:
         User.objects.create(username=form[0], email=form[0])
         raise AssertionError("Expected")
 
-    @router.rpc(anyone)
+    @router.rpc
     def sync_unexpected(request: HttpRequest, form: list[str]) -> None:
         User.objects.create(username=form[0], email=form[0])
         1 / 0
@@ -690,12 +687,12 @@ async def test_sync_rpc_rolls_back_on_errors(rf: Any) -> None:
 async def test_async_rpc_does_not_roll_back_on_errors(rf: Any) -> None:
     router = Router(HttpRequest)
 
-    @router.rpc(anyone)
+    @router.rpc
     async def async_expected(request: HttpRequest, form: list[str]) -> None:
         await sync_to_async(User.objects.create)(username=form[0], email=form[0])
         raise AssertionError("Expected")
 
-    @router.rpc(anyone)
+    @router.rpc
     async def async_unexpected(request: HttpRequest, form: list[str]) -> None:
         await sync_to_async(User.objects.create)(username=form[0], email=form[0])
         1 / 0
@@ -730,7 +727,7 @@ async def test_async_rpc_does_not_roll_back_on_errors(rf: Any) -> None:
 async def test_returns_single_model(rf: Any, schema_env: Any) -> None:
     router = Router(HttpRequest)
 
-    @router.rpc(anyone)
+    @router.rpc
     def get_user_returns(request: Any, form: list[int]) -> ReturnsPick.returns:
         return User.objects.get(id=form[0])
 
@@ -761,7 +758,7 @@ async def test_returns_list_of_models(rf: Any, schema_env: Any) -> None:
     email1 = unique_email()
     email2 = unique_email()
 
-    @router.rpc(anyone)
+    @router.rpc
     def list_users_returns(
         request: Any, form: list[int]
     ) -> list[ListReturnsPick.returns]:
@@ -793,7 +790,7 @@ async def test_returns_list_of_models(rf: Any, schema_env: Any) -> None:
 async def test_returns_nullable(rf: Any, schema_env: Any) -> None:
     router = Router(HttpRequest)
 
-    @router.rpc(anyone)
+    @router.rpc
     def maybe_user_returns(
         request: Any, form: list[int]
     ) -> NullableReturnsPick.returns | None:
@@ -970,7 +967,7 @@ async def test_returns_with_extra_fields(rf: Any, schema_env: Any) -> None:
     """RPC handler returns PickProxy, response includes both model fields and extras."""
     router = Router(HttpRequest)
 
-    @router.rpc(anyone)
+    @router.rpc
     def get_user_with_score(request: Any, form: list[int]) -> ExtraFieldsPick.returns:
         user = User.objects.get(id=form[0])
         return PickProxy(user, score=42)
@@ -1093,7 +1090,7 @@ async def test_observer_notified(
 
     router = Router(HttpRequest)
 
-    @router.rpc(anyone, log=True)
+    @router.rpc(log=True)
     async def observed(request: HttpRequest, form: ObserverInput) -> int:
         if exc:
             raise exc
@@ -1121,28 +1118,29 @@ async def test_observer_notified(
 
 @pytest.mark.asyncio
 async def test_router_principal_injection(settings: Any, rf: Any) -> None:
-    """Access functions return the principal — any value — and the handler
-    receives it as its first (positionally excluded) parameter. Parameters
-    typed HttpRequest beyond the principal slot are injected."""
+    """A scope resolves the principal — any value — and the handler receives
+    it as its first (positionally excluded) parameter. Parameters typed
+    HttpRequest beyond the principal slot are injected."""
     settings.DEBUG = False
 
-    async def authenticated(request: HttpRequest) -> User | Literal[False]:
+    router = Router()  # request_type defaults to HttpRequest
+
+    @router.scope
+    def authenticated(request: HttpRequest) -> "User | Literal[False]":
         if isinstance(request.user, AnonymousUser):
             return False
         assert isinstance(request.user, User)
         return request.user
 
-    router = Router()  # request_type defaults to HttpRequest
-
-    @router.rpc(authenticated, atomic_requests=False)
+    @authenticated.rpc(atomic_requests=False)
     def whoami(user: User) -> str:
         return user.username
 
-    @router.rpc(authenticated, atomic_requests=False)
+    @authenticated.rpc(atomic_requests=False)
     def with_request(user: User, request: HttpRequest) -> str:
         return f"{user.username}:{request.method}"
 
-    @router.rpc(authenticated, atomic_requests=False)
+    @authenticated.rpc(atomic_requests=False)
     def with_request_and_form(
         user: User, request: HttpRequest, form: PrincipalEchoForm
     ) -> str:
@@ -1205,7 +1203,7 @@ async def test_rpc_accepts_scopes(rf: Any) -> None:
             return HttpResponseRedirect("/login/")
         return Box(pk=0)
 
-    @router.scope(parent=gate)
+    @gate.scope
     def item(box: Box, *, item_id: int) -> "Box | HttpResponse":
         return Box(pk=item_id)
 

--- a/tests/transport.py
+++ b/tests/transport.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import types
 import uuid
 from dataclasses import dataclass
 
@@ -41,7 +42,7 @@ def _pages_router() -> Router[HttpRequest]:
     def area(request: HttpRequest) -> Area | HttpResponse:
         raise NotImplementedError
 
-    @router.index(area)
+    @area.index
     def area_list(a: Area, request: HttpRequest) -> HttpResponse:
         raise NotImplementedError
 
@@ -76,5 +77,34 @@ def test_mount_rejects_duplicate_name_across_kinds() -> None:
 
 
 def test_mount_rejects_non_mountable() -> None:
-    with pytest.raises(TypeError, match="not a Mountable"):
+    with pytest.raises(TypeError, match="not a module or Mountable"):
         mount(object())  # type: ignore[arg-type]
+
+
+def _module(name: str, router: Router[HttpRequest]) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.router = router  # type: ignore[attr-defined]
+    return module
+
+
+def test_mount_accepts_a_module_and_resolves_its_router() -> None:
+    # A module is the idiomatic argument: mount takes its `router`. The scope
+    # and view in `_pages_router` are defined in THIS module, so the module's
+    # name must match for the registration check to pass.
+    patterns = mount(_module(__name__, _pages_router()))
+    assert [pattern.name for pattern in patterns] == ["area_list"]
+
+
+def test_mount_dedupes_a_re_exported_router_by_identity() -> None:
+    # The shared-tree case: several modules re-export one router. Passing it
+    # via each mounts it once, not once-per-module (which would be a duplicate).
+    shared = _pages_router()
+    patterns = mount(_module(__name__, shared), _module(__name__, shared))
+    assert [pattern.name for pattern in patterns] == ["area_list"]
+
+
+def test_mount_rejects_a_module_that_registered_nothing() -> None:
+    # `_pages_router`'s registrations belong to this module, not "unrelated",
+    # so mount cannot verify the listed module contributed — a boot error.
+    with pytest.raises(TypeError, match="registered no scopes or routes"):
+        mount(_module("unrelated", _pages_router()))

--- a/tests/views.py
+++ b/tests/views.py
@@ -35,34 +35,34 @@ def stuff(request: HttpRequest) -> Area | HttpResponse:
     return Area(label="root")
 
 
-@router.scope(parent=stuff)
+@stuff.scope
 def thing(area: Area, *, thing_id: int) -> Thing | HttpResponse:
     if thing_id == 404:
         return _response("missing")
     return Thing(pk=thing_id)
 
 
-@router.index(stuff)
+@stuff.index
 def stuff_list(area: Area, request: HttpRequest) -> HttpResponse:
     return _response(f"list:{area.label}")
 
 
-@router.view(stuff)
+@stuff.view
 def stuff_check_ins(area: Area, request: HttpRequest) -> HttpResponse:
     return _response("check-ins")
 
 
-@router.index(thing)
+@thing.index
 def thing_detail(item: Thing, request: HttpRequest) -> HttpResponse:
     return _response(f"detail:{item.pk}")
 
 
-@router.view(thing)
+@thing.view
 def thing_export(item: Thing, area: Area, request: HttpRequest) -> HttpResponse:
     return _response(f"export:{item.pk}:{area.label}")
 
 
-@router.view(thing_detail)
+@thing.view
 def thing_notes(item: Thing, request: HttpRequest, *, key: str) -> HttpResponse:
     return _response(f"notes:{item.pk}:{key}")
 
@@ -124,7 +124,7 @@ def test_bad_url_param_annotation() -> None:
 def test_bad_leaf_name() -> None:
     with pytest.raises(TypeError, match="must start with"):
 
-        @router.view(stuff)
+        @stuff.view
         def unrelated_name(area: Area, request: HttpRequest) -> HttpResponse:
             raise NotImplementedError
 
@@ -132,7 +132,7 @@ def test_bad_leaf_name() -> None:
 def test_bad_arity() -> None:
     with pytest.raises(TypeError, match="must take"):
 
-        @router.view(stuff)  # type: ignore[arg-type]
+        @stuff.view  # type: ignore[arg-type]
         def stuff_broken(area: Area) -> HttpResponse:
             raise NotImplementedError
 
@@ -140,7 +140,7 @@ def test_bad_arity() -> None:
 def test_params_banned_in_path_strings() -> None:
     with pytest.raises(TypeError, match="static words only"):
 
-        @router.view(stuff, path="a/<int:b>")
+        @stuff.view(path="a/<int:b>")
         def stuff_bad_path(area: Area, request: HttpRequest) -> HttpResponse:
             raise NotImplementedError
 
@@ -152,11 +152,11 @@ def test_duplicate_route_rejected() -> None:
     def area(request: HttpRequest) -> Area | HttpResponse:
         raise NotImplementedError
 
-    @other.index(area)
+    @area.index
     def area_list(a: Area, request: HttpRequest) -> HttpResponse:
         raise NotImplementedError
 
-    @other.index(area)
+    @area.index
     def area_detail(a: Area, request: HttpRequest) -> HttpResponse:
         raise NotImplementedError
 
@@ -173,9 +173,53 @@ def test_empty_path_on_view_rejected() -> None:
 
     with pytest.raises(TypeError, match="router.index"):
 
-        @other.view(area, path="")
+        @area.view(path="")
         def area_home(a: Area, request: HttpRequest) -> HttpResponse:
             raise NotImplementedError
+
+
+def test_worded_param_scope(rf: object) -> None:
+    # path= pins words on a param scope: one edge carries the word, the
+    # param, and the resolution (truth/<uuid> needs no pass-through).
+    other = Router()
+
+    @other.scope
+    def area(request: HttpRequest) -> Area | HttpResponse:
+        return Area(label="a")
+
+    @area.scope(path="truth")
+    def truth_item(a: Area, *, thing_id: int) -> Thing | HttpResponse:
+        return Thing(pk=thing_id)
+
+    @truth_item.index
+    def truth_item_page(item: Thing, request: HttpRequest) -> HttpResponse:
+        return _response(f"truth:{item.pk}")
+
+    assert other.routes() == [("area/truth/<int:thing_id>/", "truth_item_page")]
+    request = rf.get("/")  # type: ignore[attr-defined]
+    assert other.endpoint(truth_item_page)(request, thing_id=4).content == b"truth:4"
+
+
+def test_child_scope_registers_on_parents_router(rf: object) -> None:
+    # The fractal form carries the router through the tree: a chain built
+    # entirely off the root scope lands its views on the root's router.
+    other = Router()
+
+    @other.scope
+    def area(request: HttpRequest) -> Area | HttpResponse:
+        return Area(label="a")
+
+    @area.scope
+    def item(a: Area, *, thing_id: int) -> Thing | HttpResponse:
+        return Thing(pk=thing_id)
+
+    @item.index
+    def item_detail(thing: Thing, request: HttpRequest) -> HttpResponse:
+        return _response(f"detail:{thing.pk}")
+
+    assert other.routes() == [("area/<int:thing_id>/", "item_detail")]
+    request = rf.get("/")  # type: ignore[attr-defined]
+    assert other.endpoint(item_detail)(request, thing_id=3).content == b"detail:3"
 
 
 def test_index_naming_lint() -> None:
@@ -187,7 +231,7 @@ def test_index_naming_lint() -> None:
 
     with pytest.raises(TypeError, match="must start with"):
 
-        @other.index(area)
+        @area.index
         def unrelated(a: Area, request: HttpRequest) -> HttpResponse:
             raise NotImplementedError
 
@@ -202,7 +246,7 @@ def test_pinned_view_name_still_linted() -> None:
 
     with pytest.raises(TypeError, match="must start with"):
 
-        @other.view(area, path="special")
+        @area.view(path="special")
         def legacy_name(a: Area, request: HttpRequest) -> HttpResponse:
             raise NotImplementedError
 
@@ -214,7 +258,7 @@ def test_uuid_param() -> None:
     def area(request: HttpRequest) -> Area | HttpResponse:
         raise NotImplementedError
 
-    @other.view(area)
+    @area.view
     def area_item(a: Area, request: HttpRequest, *, ref: uuid.UUID) -> HttpResponse:
         raise NotImplementedError
 
@@ -228,13 +272,13 @@ def test_scope_with_request(rf: object) -> None:
     def area(request: HttpRequest) -> Area | HttpResponse:
         return Area(label="a")
 
-    @other.scope(parent=area, path="")
+    @area.scope(path="")
     def gated(a: Area, request: HttpRequest) -> Thing | HttpResponse:
         if request.META.get("HTTP_X_DENY"):
             return _response("nope")
         return Thing(pk=1)
 
-    @other.view(gated)
+    @gated.view
     def gated_page(item: Thing, request: HttpRequest) -> HttpResponse:
         return _response(f"page:{item.pk}")
 
@@ -260,11 +304,11 @@ def test_scope_false_denial(rf: object, settings: object) -> None:
             return False
         return Area(label="a")
 
-    @other.scope(parent=area)
+    @area.scope
     def item(a: Area, *, thing_id: int) -> "Thing | HttpResponse | Literal[False]":
         return Thing(pk=thing_id)
 
-    @other.view(item)
+    @item.view
     def item_page(thing: Thing, request: HttpRequest) -> HttpResponse:
         return _response(f"page:{thing.pk}")
 
@@ -297,7 +341,7 @@ def test_scope_true_rejected(rf: object) -> None:
     def area(request: HttpRequest) -> "Area | HttpResponse":
         return True  # type: ignore[return-value]
 
-    @other.index(area)
+    @area.index
     def area_list(a: Area, request: HttpRequest) -> HttpResponse:
         raise NotImplementedError
 
@@ -334,7 +378,7 @@ def test_template_returns(rf: object) -> None:
     def area(request: HttpRequest) -> Area | HttpResponse:
         return Area(label="a")
 
-    @other.view(area)
+    @area.view
     def area_page(a: Area, request: HttpRequest) -> FakePage | HttpResponse:
         if request.META.get("HTTP_X_REDIRECT"):
             return _response("went-elsewhere")
@@ -362,7 +406,7 @@ def test_non_renderable_return_rejected(rf: object) -> None:
     def area(request: HttpRequest) -> Area | HttpResponse:
         return Area(label="a")
 
-    @other.view(area)
+    @area.view
     def area_bogus(a: Area, request: HttpRequest) -> HttpResponse:
         return None  # type: ignore[return-value]
 
@@ -371,28 +415,29 @@ def test_non_renderable_return_rejected(rf: object) -> None:
         other.endpoint(area_bogus)(request)
 
 
-def test_root_propagates_through_two_arity_parent(rf: object) -> None:
-    """The corner the phantom exists for: the parent view never mentions
-    the root in its signature, yet the child's 3-arity shape still binds
-    TRoot statically (via __view_root__) and receives it at runtime."""
+def test_root_recoverable_beside_a_two_arity_page(rf: object) -> None:
+    """A page that never mentions the root in its signature doesn't strand
+    its URL-neighbors: the pinned sibling one word deeper binds TRoot
+    through the Scope generics and receives it at runtime. Nesting under a
+    page's URL is path= pins — the word repeats, visibly."""
     other = Router()
 
     @other.scope
     def area(request: HttpRequest) -> Area | HttpResponse:
         return Area(label="root-product")
 
-    @other.scope(parent=area)
+    @area.scope
     def item(a: Area, *, thing_id: int) -> Thing | HttpResponse:
         return Thing(pk=thing_id)
 
-    @other.view(item, path="page")
+    @item.view(path="page")
     def item_page(thing: Thing, request: HttpRequest) -> HttpResponse:  # 2-arity
         return _response(f"page:{thing.pk}")
 
-    @other.view(item_page, path="deep")
+    @item.view(path="page/deep")
     def item_page_deep(
         thing: Thing, root: Area, request: HttpRequest
-    ) -> HttpResponse:  # 3-arity child of a 2-arity parent
+    ) -> HttpResponse:  # 3-arity sibling one word below the 2-arity page
         return _response(f"deep:{thing.pk}:{root.label}")
 
     request = rf.get("/")  # type: ignore[attr-defined]


### PR DESCRIPTION
### The tree is written as a tree

A \`Scope\` is now a router node: children register on their parent (\`@parent.scope\`, \`@parent.view\`, \`@parent.index\`), not on the router with a \`parent=\` kwarg. The parent's product type binds directly into every child-signature check, and cross-router parenting is unrepresentable. The router itself only plants roots (\`@router.scope\`, with \`RootScopeBinder\` for \`path=\` pins).

View-parenting is removed: a registered view is the original plain function, so nothing hangs off it. Nesting under a page's URL is spelled with \`path=\` pins on siblings — the word repeats visibly, and a typo 404s instead of silently forking the URL space. The \`__view_root__\` phantom and \`RegisteredView\` protocol go away; \`ViewFn\` drops its phantom root param.

### Built-in gates

\`router.authenticated\` and \`router.maybe_authenticated\` ship as cached properties — hand-constructed root scopes whose product types as the project's concrete \`User\` via django-stubs' \`_User\` (resolved at the consumer's mypy run, degrading to \`Any\` on older stubs). \`authenticated\` injects the user or denies canonically; \`maybe_authenticated\` injects \`User | None\` and never denies.

### Bare \`@router.rpc\` and \`@scope.rpc\`

The access-function form of \`rpc\`/\`query\` is replaced: a public procedure is bare \`@router.rpc\` (the request is the principal), and a gated one is \`@scope.rpc\` — sugar over \`@router.rpc(scope)\`, with the chain's params becoming URL segments exactly as on a view.

### \`mount()\` takes modules

The idiomatic argument to \`mount()\` is an imported module owning a \`router\`. The module is verified via \`Router.contributing_modules()\`: a listed module that registered nothing is a boot error naming it, not a silently missing page. Routers dedupe by identity, so shared-tree modules re-exporting one router mount it once. Raw \`Mountable\`s are still accepted.

### Async authoring

Scope functions may be \`async def\`; the chain resolves sync-driven, bouncing async scopes through \`async_to_sync\` so ORM work under an atomic request re-joins the transaction thread.

### Migration

- \`@router.scope(parent=x)\` → \`@x.scope\`; \`@router.view(x)\` → \`@x.view\`; \`@router.index(x)\` → \`@x.index\`.
- View-parenting (\`@router.view(some_view)\`) → \`path=\` pins on the scope (\`@x.view(path="page/deep")\`).
- \`@router.rpc(access_fn)\` → bare \`@router.rpc\` (public) or a scope (\`@scope.rpc\`).

### Tests

Route-table, chain-execution, and typing coverage updated to the tree forms; new coverage for worded param scopes, fractal child registration, module mounting (resolution, identity dedupe, empty-module rejection).
