### PR TITLE
Fix create-django-app build

### DIFF
--- a/packages/create-django-app/tsconfig.json
+++ b/packages/create-django-app/tsconfig.json
@@ -1,8 +1,9 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es2020",
         "module": "commonjs",
-        "lib": ["es6", "dom"],
+        "lib": ["es2020", "dom"],
+        "types": ["node"],
         "strict": true,
         "esModuleInterop": true
     },


### PR DESCRIPTION
The Continuous Delivery "Publish release" job has been failing on main since 2026-07-10 (first on #461's merge — it predates the current PR batch): \`create-django-app\`'s \`prepublishOnly\` runs \`tsc\`, and TypeScript 6 rejects \`target: es5\` with \`TS5107\` ("deprecated and will stop functioning in TypeScript 7.0"). The package pins no TypeScript of its own, so the environment's compiler decides.

Two changes, both required under TS 6 (verified locally on 6.0.3, the same major CI floats onto):

- \`target\`/\`lib\` → \`es2020\` — the package is a Node CLI; es2020 output is safe on every supported Node.
- \`"types": ["node"]\` — the es5 config error was aborting \`tsc\` before type-checking, masking that the node globals (\`fs\`, \`process\`, \`__dirname\`) were never explicitly wired up; TS 6 no longer picks the hoisted \`@types/node\` up implicitly here.

No source changes; \`tsc --noEmit\` passes.