### PR TITLE
Add docs for picks, templates, views, and RPC

### DIFF
--- a/website/client/templates/Documentation.tsx
+++ b/website/client/templates/Documentation.tsx
@@ -6,6 +6,23 @@ import ReactMarkdown from "react-markdown";
 import {Code} from "@client/components/Code";
 import {Layout} from "@client/components/Layout";
 
+// JSON.stringify cannot walk an element tree: under React 19 a context is
+// circular (Context.Provider === Context), so any context in the tree throws.
+const safeStringify = (value: unknown): string => {
+    const seen = new WeakSet();
+    return (
+        JSON.stringify(value, (_, child: unknown) => {
+            if (typeof child === "object" && child !== null) {
+                if (seen.has(child)) {
+                    return undefined;
+                }
+                seen.add(child);
+            }
+            return child;
+        }) ?? ""
+    );
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getAnchor = (children: any) => {
     const heading: string = // eslint-disable-line
@@ -13,7 +30,7 @@ const getAnchor = (children: any) => {
 
     // Brittle and doesn't always work.
     // const keepDots: boolean = children?.[0]?.type === "code";
-    const keepDots: boolean = JSON.stringify(children).includes("code");
+    const keepDots: boolean = safeStringify(children).includes("code");
     const regex = keepDots === true ? /[^.a-zA-Z0-9 ]/g : /[^a-zA-Z0-9 ]/g;
     const anchor = heading.toLowerCase().replace(regex, "").replace(/\s+/g, "-");
 
@@ -124,7 +141,7 @@ export const Template = (props: server.documentation.templates.Documentation) =>
                                 return <h3 id={anchor}>{children}</h3>;
                             },
                             blockquote: (props) => {
-                                const isWarning = JSON.stringify(
+                                const isWarning = safeStringify(
                                     props.children,
                                 ).includes("Warning");
                                 return (

--- a/website/client/templates/HomePage.tsx
+++ b/website/client/templates/HomePage.tsx
@@ -179,11 +179,11 @@ export const Template = (props: server.documentation.templates.HomePage) => (
                     <Code language="tsx">
                         {outdent`
                             import React from "react";
-                            import {CSRFToken, Form, templates} from "@reactivated";
+                            import {CSRFToken, Form, server} from "@reactivated";
 
                             import {Layout} from "@client/components/Layout";
 
-                            export const Template = (props: server.documentation.templates.HomePage) => (
+                            export const Template = (props: server.example.templates.HomePage) => (
                                 <Layout title="Sign Up">
                                     <h1>Sign Up</h1>
                                     <form method="POST">
@@ -214,7 +214,10 @@ export const Template = (props: server.documentation.templates.HomePage) => (
                 <div className="homePageFeatures">
                     <div>
                         <h2>Type Safe</h2>
-                        <p>TypeScript and Mypy built-in. Catch mistakes early.</p>
+                        <p>
+                            TypeScript and Mypy built-in. One set of types, from the
+                            database to the DOM.
+                        </p>
                     </div>
                     <div>
                         <h2>Deployment Ready</h2>
@@ -320,22 +323,58 @@ export const Template = (props: server.documentation.templates.HomePage) => (
                 <Highlight>
                     <Code language="python">
                         {outdent`
-                            class LoginForm(forms.Form):
-                                email = forms.EmailField()
-                                password = forms.PasswordField()
+                            from reactivated.pick import pick
+                            from reactivated.templates import Template
 
-                            @template
-                            class Login(NamedTuple):
-                                form: forms.LoginForm
+                            BookSummary = pick(models.Book, fields=["id", "title", "author.name"])
+
+                            class Library(Template):
+                                books: list[BookSummary.returns]
                         `}
                     </Code>
                     <div>
                         <h2>Type safety — everywhere</h2>
                         <p>All roads lead to types. So embrace them.</p>
                         <p>
-                            Type your Django code, and all of your React templates will
-                            be typed automatically.
+                            Pick the exact model fields you need. Your React templates
+                            are typed automatically, all the way down:{" "}
+                            <code>book.author.name</code> is a string on both sides.
                         </p>
+                    </div>
+                </Highlight>
+                <Highlight>
+                    <div>
+                        <h2>Call the server like a function</h2>
+                        <p>REST endpoints and ad-hoc fetch calls are no way to live.</p>
+                        <p>
+                            Declare a procedure in Python. Call it from TypeScript.
+                            Inputs validated, outputs typed, and even authentication is
+                            proven by mypy: the handler receives the logged-in user, not
+                            a request.
+                        </p>
+                    </div>
+                    <div>
+                        <Code language="python">
+                            {outdent`
+                                @router.authenticated.rpc
+                                def rate_book(user: User, form: RateForm) -> float:
+                                    book = models.Book.objects.get(pk=form.book_id)
+                                    book.ratings.create(user=user, stars=form.stars)
+                                    return book.average_rating
+                            `}
+                        </Code>
+                        <Code language="tsx">
+                            {outdent`
+                                const result = await server.store.api.rate_book({
+                                    book_id: 5,
+                                    stars: 4,
+                                });
+
+                                if (result.type === "success") {
+                                    setAverage(result.data); // number
+                                }
+                            `}
+                        </Code>
                     </div>
                 </Highlight>
                 <Highlight>
@@ -373,7 +412,7 @@ export const Template = (props: server.documentation.templates.HomePage) => (
                                 <CSRFToken />
                                 <Form handler={form} as="p" fields={fields} />
                                 <button type="submit">Send wire</button>
-                            </>;
+                            </form>;
                         };
                     `}</Code>
                     </div>

--- a/website/server/docs/api.md
+++ b/website/server/docs/api.md
@@ -4,19 +4,15 @@ Reactivated provides you with an API to make working with Django and React easie
 
 ## Python / Django
 
-### `reactivated.template`
+### `reactivated.templates.Template`
 
-Use the `template` decorator to define your template structure. By convention, these
-templates go in `templates.py` of the corresponding app. Simply import `NamedTuple` and
-`template` then define the context.
+Subclass `Template` to define your template structure. By convention, these
+templates go in `templates.py` of the corresponding app.
 
 ```python
-from typing import NamedTuple
+from reactivated.templates import Template
 
-from reactivated import template
-
-@template
-class MyTemplate(NamedTuple):
+class MyTemplate(Template):
     name: str
     title: str
     age: int
@@ -41,14 +37,17 @@ def my_view(request: HttpRequest) -> HttpResponse:
 
 ```
 
-> **Note**: Reactivated will look for a **default export** from
+Templates are Pydantic models, so construction validates. See the
+[templates documentation](/documentation/templates/) for the full system.
+
+> **Note**: Reactivated will look for an export named `Template` from
 > `BASE_DIR/client/templates/TEMPLATE_NAME.tsx`
 
-### `reactivated.Pick`
+### `reactivated.pick.pick`
 
 Passing model instances to a React template is tricky. We need to serialize the model
 instance, but for many reasons, can't simply send over every field. Instead, we
-explicitly tell our template what fields to pick from the model.
+explicitly pick the fields we want from the model.
 
 Using the following models:
 
@@ -62,41 +61,23 @@ class Book(models.Model):
     title = models.CharField(max_length=100)
 ```
 
-We can use `Pick` as follows:
+We can declare a pick and use it in a template:
 
 ```python
-from reactivated import Pick, template
-from typing import Literal
+from reactivated.pick import pick
+from reactivated.templates import Template
 
 from . import models
 
-@template
-class BookDetail(NamedTuple):
-    book: Pick[models.Book, Literal["name", "author.name", "author.age"]]
+BookPick = pick(models.Book, fields=["title", "author.name", "author.age"])
+
+class BookDetail(Template):
+    book: BookPick.returns
+    related_books: list[BookPick.returns]
 ```
 
-To use a list of book instances, just wrap everything with `List` from `typing`:
-
-```python
-@template
-class BookDetail(NamedTuple):
-    book: Pick[models.Book, Literal["name", "author.name", "author.age"]]
-    related_books: List[Pick[models.Book, Literal["name", "author.name", "author.age"]]]
-```
-
-You'll notice we're repeating ourselves quite a bit. We can alias our `Pick` and reuse
-it:
-
-```python
-Book = Pick[models.Book, Literal["name", "author.name", "author.age"]]
-
-@template
-class BookDetail(NamedTuple):
-    book: Book
-    related_books: List[Book}
-```
-
-We would then render the template as follows:
+The `.returns` annotation lets the view pass Django instances directly; serialization
+picks out the declared fields:
 
 ```python
 def book_detail(request: HttpRequest, *, book_id: int) -> HttpResponse:
@@ -107,38 +88,41 @@ def book_detail(request: HttpRequest, *, book_id: int) -> HttpResponse:
     ).render(request)
 ```
 
-### `reactivated.interface`
+Picks do much more — input and output sides, extra fields, deep type checking through
+the mypy plugin. See the [picks documentation](/documentation/picks/).
 
-This behaves identically to the `template` decorator. But unlike `template`, it will not
-expect you to create a corresponding `.tsx` file.
+### `reactivated.router.Router`
 
-This is useful for creating AJAX-only endpoints and statically typing them.
-
-See the [AJAX concepts](/documentation/concepts/) for more information.
+The router registers pages and procedures alike: URLs derive from function names and
+signatures, and _scopes_ make access control structural. See the
+[views](/documentation/views/) and [RPC](/documentation/rpc/) documentation.
 
 ## TypeScript / React
 
-### `templates`
+### `server`
 
-When you use the `reactivated.template` decorator in your Django code, Reactivated will
-generate types for you.
+Everything you declare in Python — templates, picks, procedures, exported enums —
+lands on the client under the `server` namespace, at the path mirroring its Python
+module. One import, one addressing scheme.
 
 For a template named `MyTemplate` inside `server/custom_app/templates.py`, you would
-then create a file named `client/templates/MyTemplate.tsx` and import `templates` like
-so:
+create a file named `client/templates/MyTemplate.tsx` and type its props like so:
 
 ```typescript
-import {templates} from "@reactivated";
+import {server} from "@reactivated";
 
-export const Template = (props: templates.MyTemplate) => (
+export const Template = (props: server.custom_app.templates.MyTemplate) => (
     <div>{props.properties_of_my_template}</div>
 );
 ```
 
-If you mismatch types, say `templates.MyOtherTemplate` and they are
+If you mismatch types and they are
 [structurally](https://www.typescriptlang.org/docs/handbook/type-compatibility.html)
 different, TypeScript will complain. If you don't create the template file or don't
 export the template correctly, TypeScript will also complain.
+
+The same addressing works for procedures (`server.custom_app.api.save_thing(...)`)
+and pick types (`server.custom_app.picks.Thing.output`).
 
 ### `Form`
 
@@ -147,9 +131,9 @@ a table. Just like Django's renderer, the outer `form` tag is _not_ included. Sa
 for the `table` tag.
 
 ```typescript
-import {CSRFToken, Form, templates} from "@reactivated";
+import {CSRFToken, Form, server} from "@reactivated";
 
-export default (props: templates.MyFormTemplate) => (
+export const Template = (props: server.custom_app.templates.MyFormTemplate) => (
     <div>
         <form method="POST">
             <CSRFToken />
@@ -183,7 +167,7 @@ Because you have access to `form.values`, this also allows you to manipulate the
 dynamically.
 
 ```typescript
-import {CSRFToken, Widget, useForm, FieldHandler, templates} from "@reactivated";
+import {CSRFToken, Widget, useForm, FieldHandler, server} from "@reactivated";
 
 const Field = (props: {field: FieldHandler}) => {
     const {field} = props;
@@ -204,7 +188,7 @@ const Field = (props: {field: FieldHandler}) => {
     );
 };
 
-export default (props: templates.MyFormTemplate) => {
+export const Template = (props: server.custom_app.templates.MyFormTemplate) => {
     const form = useForm({form: props.form});
 
     return (
@@ -236,9 +220,9 @@ Just like the `Form` tag, you can use the `FormSet` component to quickly prototy
 form sets.
 
 ```typescript
-import {CSRFToken, FormSet, templates} from "@reactivated";
+import {CSRFToken, FormSet, server} from "@reactivated";
 
-export default (props: templates.MyFormSetTemplate) => (
+export const Template = (props: server.custom_app.templates.MyFormSetTemplate) => (
     <div>
         <form method="POST">
             <CSRFToken />
@@ -260,9 +244,9 @@ each form in the form set under `forms`. From then on, you can render the forms 
 as with the `useForm` example. But don't forget `ManagementForm`.
 
 ```typescript
-import {CSRFToken, useFormSet, ManagementForm, templates} from "@reactivated";
+import {CSRFToken, useFormSet, ManagementForm, server} from "@reactivated";
 
-export default (props: templates.MyFormSetTemplate) => {
+export const Template = (props: server.custom_app.templates.MyFormSetTemplate) => {
     const formSet = useFormSet({formSet: props.formSet});
 
     return (

--- a/website/server/docs/api.md
+++ b/website/server/docs/api.md
@@ -88,7 +88,7 @@ def book_detail(request: HttpRequest, *, book_id: int) -> HttpResponse:
     ).render(request)
 ```
 
-Picks do much more — input and output sides, extra fields, deep type checking through
+Picks do much more: input and output sides, extra fields, deep type checking through
 the mypy plugin. See the [picks documentation](/documentation/picks/).
 
 ### `reactivated.router.Router`
@@ -101,7 +101,7 @@ signatures, and _scopes_ make access control structural. See the
 
 ### `server`
 
-Everything you declare in Python — templates, picks, procedures, exported enums —
+Everything you declare in Python (templates, picks, procedures, exported enums)
 lands on the client under the `server` namespace, at the path mirroring its Python
 module. One import, one addressing scheme.
 

--- a/website/server/docs/concepts.md
+++ b/website/server/docs/concepts.md
@@ -158,8 +158,8 @@ The tried-and-true [Post/Redirect/Get](https://en.wikipedia.org/wiki/Post/Redire
 workflow for forms will serve you well. Server-rendered pages with full reloads get you
 much further than the SPA industry admits.
 
-When you do want app-like behavior — saving without a reload, live search, optimistic
-UI — Reactivated has a first-class answer: [RPC](/documentation/rpc/). Declare a
+When you do want app-like behavior (saving without a reload, live search, optimistic
+UI), Reactivated has a first-class answer: [RPC](/documentation/rpc/). Declare a
 procedure in Python, call it from TypeScript as a typed async function:
 
 ```python
@@ -207,6 +207,6 @@ Reactivated encourages the following structure, but we
             -   api.py
 ```
 
-Generated code lands in `client/generated/` — gitignored, regenerated on dev server
+Generated code lands in `client/generated/`: gitignored, regenerated on dev server
 start, and pruned of orphans automatically. You never edit it, but you can always read
 it.

--- a/website/server/docs/concepts.md
+++ b/website/server/docs/concepts.md
@@ -17,40 +17,50 @@ Imagine we have a template that expects an instance of a `Book` model and a
 Without Reactivated, we would render the template like so:
 
 ```python
-render(request, "my_template.html", {"book": book_instance, "form": form_instance})`
+render(request, "my_template.html", {"book": book_instance, "form": form_instance})
 ```
 
 With Reactivated, we first declare our template structure:
 
 ```python
-from reactivated import Pick, template
-from typing import Literal
+from typing import Annotated
 
-@template
-class MyTemplate(NamedTuple):
-    book: Pick[models.Book, Literal["name"]]
-    form: forms.CommentForm
+from reactivated.forms import DjangoForm
+from reactivated.pick import pick
+from reactivated.templates import Template
+
+from . import forms, models
+
+BookPick = pick(models.Book, fields=["name"])
+
+
+class MyTemplate(Template):
+    book: BookPick.returns
+    form: Annotated[forms.CommentForm, DjangoForm]
 ```
 
 Then we render it like so, giving us an `HttpResponse`:
 
 ```python
-MyTemplate(book=book_instance, form=form_instance).render(request)
+MyTemplate(book=book_instance, form=comment_form).render(request)
 ```
 
 ### Models
 
-Something surely stands out in the template above: we wrapped `Book` with `Pick` and
-specified a `"name"` field. This is because we need to tell Reactivated what fields we
+Something surely stands out in the template above: we declared a _pick_ of `Book` with
+just the `"name"` field. This is because we need to tell Reactivated what fields we
 want sent to React from the model instance. You _cannot_ pass entire models as
 Reactivated would have no way of knowing what fields you are going to use.
 
-Think of `Pick` as a very quick way to create a serializer for your models.
+Think of a pick as a very quick way to create a serializer for your models. Except it
+validates, generates TypeScript, and supports deep field access on both sides. Picks
+are worth understanding well; they have [their own documentation](/documentation/picks/).
 
 ### Forms
 
-Unlike models, forms can be passed whole to your templates. Reactivated knows what to
-do.
+Django forms can be passed to your templates through the `DjangoForm` annotation shown
+above. Reactivated knows what to do: the form renders with its fields, errors, and
+widgets fully typed on the React side.
 
 ## Views
 
@@ -69,21 +79,29 @@ def comment_on_book(request: HttpRequest, *, book_id: int) -> HttpResponse:
     return MyTemplate(book=book_instance, form=comment_form).render(request)
 ```
 
+Classic `urls.py` wiring works exactly as you know it. But Reactivated also ships a
+[router](/documentation/views/) that derives URLs from your function signatures and
+makes access control structural. Use it when the bookkeeping starts to hurt.
+
 ## The React Side
 
 With your Python code declared above, Reactivated would expect a `Template` export at
 `client/templates/MyTemplate.tsx` for a React component that accepts the context you
-declared. As you can see, types are automatically generated:
+declared.
+
+Types are generated automatically under the `server` namespace, which mirrors your
+Python tree: a template declared in `server/books_app/templates.py` is typed as
+`server.books_app.templates.MyTemplate`.
 
 ```typescript
 import React from "react";
 
-import {templates, Form} from "@reactivated";
+import {Form, server} from "@reactivated";
 
-export const Template = (props: templates.MyTemplate) => (
+export const Template = (props: server.books_app.templates.MyTemplate) => (
     <div>
         <h1>{props.book.name}</h1>
-        <form>
+        <form method="POST">
             <Form as="p" form={props.form} />
             <button type="submit">Submit</button>
         </form>
@@ -107,17 +125,17 @@ include items, the request object, settings, and more into your template context
 The main examples are your CSRF token, the request object, and
 [messages](https://docs.djangoproject.com/en/4.0/ref/contrib/messages/).
 
-When using a React template, you'll have access to your `props` as declared using the
-`template` decorator. But you can also access context processors by importing `Context`
+When using a React template, you'll have access to your `props` as declared on your
+`Template` class. But you can also access context processors by importing `Context`
 and using `React.useContext`. Like everything else in Reactivated, this will be
 statically typed.
 
 ```typescript
 import React from "react";
 
-import {templates, Context} from "@reactivated";
+import {Context, server} from "@reactivated";
 
-export const Template = (props: templates.MyTemplate) => {
+export const Template = (props: server.books_app.templates.MyTemplate) => {
     const context = React.useContext(Context);
 
     return (
@@ -134,141 +152,32 @@ Currently, only your own context processors and a few built-in ones are supporte
 you write your own context processor, be sure to add it to the `TEMPLATES` setting, and
 make sure to properly annotate its return value.
 
-### AJAX
+### Dynamic behavior
 
 The tried-and-true [Post/Redirect/Get](https://en.wikipedia.org/wiki/Post/Redirect/Get)
-workflow for forms will serve you well. But sometimes you want more dynamic, app-like
-behavior. Enter AJAX.
+workflow for forms will serve you well. Server-rendered pages with full reloads get you
+much further than the SPA industry admits.
 
-From our example app, you can see how to use `fetch` and `FormData` to submit a form
-without reloading the browser.
+When you do want app-like behavior — saving without a reload, live search, optimistic
+UI — Reactivated has a first-class answer: [RPC](/documentation/rpc/). Declare a
+procedure in Python, call it from TypeScript as a typed async function:
 
 ```python
-def poll_comments(request: HttpRequest, question_id: int) -> HttpResponse:
-    question = get_object_or_404(models.Question, id=question_id)
-    form = forms.Comment(
-        request.POST or None, instance=models.Comment(question=question)
-    )
-
-    if form.is_valid():
-        form.save()
-
-        if request.accepts("application/json") is False:
-            return redirect("poll_comments", question.pk)
-
-    return templates.PollComments(question=question, form=form).render(request)
+@router.authenticated.rpc
+def comment_on_book(user: User, form: CommentForm) -> None:
+    ...
 ```
-
-And a redacted version of the React template:
 
 ```typescript
-export const Template = (props: templates.PollComments) => {
-    const {question} = props;
-    const {request} = React.useContext(Context);
-    const [comments, setComments] = React.useState(question.comments);
-    const form = useForm({form: props.form});
-    const title = `${props.question.question_text} comments`;
-
-    const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-        const formElement = event.currentTarget;
-        const formData = new FormData(formElement);
-
-        const response = await fetch(request.path, {
-            method: "POST",
-            body: formData,
-            headers: {
-                Accept: "application/json",
-            },
-        });
-
-        const data = (
-            (await response.json()) as {props: templates.PollComments}
-        ).props;
-
-        setComments(data.question.comments);
-
-        if (data.form.errors != null) {
-            form.setErrors(data.form.errors);
-        } else {
-            form.reset();
-        }
-    };
-
-    return (
-        <Layout title={title}>
-            <form
-                action={request.path}
-                method="post"
-                onSubmit={onSubmit}
-            >
-
-                <Form as="p" form={form} />
-                <button type="submit">Comment</forms.button>
-            </form>
-        </Layout>
-    );
-};
-```
-
-You'll notice this will work with or without JavaScript enabled. Moreover, data is
-reloaded with a single request.
-
-You can use our [setup script](/documentation/getting-started/) to try out the full
-example and review the code.
-
-In the future, Reactivated will provide higher-level helpers to streamline this process
-but this should illustrate the general flow.
-
-### REST-style endpoint
-
-We may want to create an AJAX only endpoint. Basically a read-only REST-style view that
-serializes a model. This is easy to do using the `interface` decorator.
-
-Inside `interfaces.py`:
-
-```python
-from typing import Literal, NamedTuple
-
-from reactivated import interface, Pick
-
-from . import models
-
-@interface
-class WidgetDetail(NamedTuple):
-    widget: Pick[models.Widget, Literal["name", "price"]]
-```
-
-Then in our `views.py`:
-
-```python
-from . import models, interfaces
-
-def widget_detail_api(request: HttpRequest, *, widget_id: int) -> HttpResponse:
-    widget = get_object_or_404(models.Widget, pk=widget_id)
-    return interfaces.WidgetDetail(widget=widget).render(request)
-```
-
-Assuming we connected this view to `/widgets/<int:question_id>/`, we could now use this
-anywhere in the React side of things by importing `interfaces` from `@reactivated`
-
-Here's a redacted example:
-
-```typescript
-import {interfaces} from "@reactivated";
-
-const response = await fetch("/widgets/5/", {
-    headers: {
-        Accept: "application/json",
-    },
+const result = await server.books_app.api.comment_on_book({
+    book_id: 5,
+    comment: "A masterpiece.",
 });
-
-const data: interfaces.WidgetDetail = await response.json();
-const {widget} = data;
 ```
 
-> **Note**: This is highly experimental. Reactivated will support first-class AJAX APIs
-> with minimal code and strong type safety.
+Inputs are validated, outputs are typed, and there are no endpoints, URLs, or response
+shapes to hand-maintain. The [RPC documentation](/documentation/rpc/) covers the whole
+system, including access control and testing.
 
 ## Project Structure
 
@@ -295,5 +204,9 @@ Reactivated encourages the following structure, but we
             -   models.py
             -   forms.py
             -   templates.py
-            -   interfaces.py
+            -   api.py
 ```
+
+Generated code lands in `client/generated/` — gitignored, regenerated on dev server
+start, and pruned of orphans automatically. You never edit it, but you can always read
+it.

--- a/website/server/docs/dev-server.md
+++ b/website/server/docs/dev-server.md
@@ -1,0 +1,83 @@
+# The Dev Server
+
+Start everything with one command:
+
+```bash
+reactivate
+```
+
+That's the whole interface. Under the hood you get Django running as ASGI
+under uvicorn, Vite serving your frontend with hot module replacement, a
+TypeScript compiler in watch mode, and client asset generation — spawned
+together, wired together, and torn down together when you hit Ctrl-C.
+
+## Two modes
+
+**Vite mode** is the default. Vite owns the user-facing port and proxies
+everything that isn't an asset to Django. You get HMR, instant saves, the
+usual modern niceties. Startup blocks until Vite is actually listening rather
+than guessing with a sleep, and fails loudly if Vite dies on boot — no
+half-started server that looks alive and serves nothing.
+
+**Build mode** (`reactivate --build`) skips the Vite dev server entirely: a
+full production client build, served by Django, rebuilt on every change. No
+HMR and slower per save, but a page load is a handful of requests instead of
+hundreds of unbundled modules. That's the mode for testing behind proxies and
+tunnels, where a module waterfall is unbearable.
+
+## Smart reload
+
+Change server code and the dev server doesn't just restart Django. It
+regenerates the client assets too, so a new pick, procedure, or template shows
+up in TypeScript on the very next save — types can't go stale mid-session. In
+build mode it rebuilds the client bundle as well.
+
+The file watches are scoped to `server/` (plus `client/` in build mode) on
+purpose. An unscoped watcher registers a recursive watch over `node_modules`
+and `.git` and melts your filesystem event daemon. Test files are excluded
+from the watch, so saving a test doesn't bounce the server you're testing
+against.
+
+## Configuration
+
+Everything is environment-driven; there are no flags to memorize beyond
+`--build`.
+
+- **`DEBUG_PORT`** (required): the user-facing port. The project's shell
+  environment derives and exports it. If it's missing, startup is an explicit
+  error telling you so.
+- **`REACTIVATED_PROCESSES`**: newline-separated sidecar commands — a
+  database tunnel, a worker, whatever your project needs running alongside.
+  They spawn with the server and get cleaned up with it. `$VAR` references
+  resolve at spawn time, including the runtime ports the server just
+  allocated. A sidecar that exits immediately warns instead of killing the
+  server, since the usual cause is another checkout already holding the
+  shared resource.
+- **`DEV_URL` / `DEV_EXTRA_URLS`**: what the startup banner prints when your
+  project fronts the server through richer hostnames or an HTTPS proxy.
+  Without them, plain localhost.
+
+## Port safety
+
+If something is already serving on `DEBUG_PORT` — usually another checkout's
+dev server — startup is an explicit error naming the port. This matters more
+than it sounds: in Vite mode the loser of a port race binds a wildcard socket
+that macOS happily lets coexist with the winner's, so it "starts" cleanly and
+never receives a single request. We'd rather tell you.
+
+## What about runserver?
+
+`python manage.py runserver` still works, unchanged. Reactivated patches it to
+generate client assets and spawn Vite and the TypeScript watcher at boot, same
+as it always has. Either way, you get the full stack.
+
+But `reactivate` is better, and here's how. Runserver generates your client
+assets once, at boot; `reactivate` regenerates them on every server change, so
+your TypeScript never drifts from your Python within a session. Runserver has
+no build mode. It can't tell you another worktree already owns your port; it
+has no concept of sidecar processes; and Django runs under WSGI's dev server
+instead of uvicorn, so async views aren't actually async while you develop.
+
+Use `runserver` if muscle memory insists. It will keep working. But
+`reactivate` is the recommended entry point, and once the banner prints your
+URL you won't go back.

--- a/website/server/docs/dev-server.md
+++ b/website/server/docs/dev-server.md
@@ -12,8 +12,7 @@ TypeScript compiler in watch mode, and client asset generation. Spawned
 together, wired together, and torn down together when you hit Ctrl-C.
 
 Nothing here needs Nix. `reactivate` is a console script installed with the
-Python package; it wants `DEBUG_PORT` set and your node modules installed,
-and that's it.
+Python package; it needs your node modules installed and nothing else.
 
 ## Two modes
 
@@ -44,14 +43,14 @@ against.
 
 ## Configuration
 
-Everything is environment-driven; there are no flags to memorize beyond
-`--build`.
+Two flags, `--build` and `--port`. Everything else is environment-driven.
 
-- **`DEBUG_PORT`** (required): the user-facing port. Projects created with the
-  [setup script](/documentation/getting-started/) already derive and export
-  this in their shell environment, so there's nothing to do. On an existing
-  project, export it yourself; any free port works. If it's missing, startup
-  is an explicit error telling you so.
+- **The port**: `--port` beats `DEBUG_PORT` beats the conventional 8000.
+  Projects created with the [setup script](/documentation/getting-started/)
+  export a stable per-checkout `DEBUG_PORT`, so parallel worktrees never
+  collide. On an existing project, just run `reactivate` and you get 8000,
+  or pass `--port` for anything else. Whichever wins is re-exported as
+  `DEBUG_PORT`, so sidecars and child processes all see the effective port.
 - **`REACTIVATED_PROCESSES`**: newline-separated sidecar commands. A database
   tunnel, a worker, whatever your project needs running alongside. They spawn
   with the server and get cleaned up with it. `$VAR` references resolve at
@@ -64,7 +63,7 @@ Everything is environment-driven; there are no flags to memorize beyond
 
 ## Port safety
 
-If something is already serving on `DEBUG_PORT`, usually another checkout's
+If something is already serving on the chosen port, usually another checkout's
 dev server, startup is an explicit error naming the port. This matters more
 than it sounds: in Vite mode the loser of a port race binds a wildcard socket
 that macOS happily lets coexist with the winner's, so it "starts" cleanly and

--- a/website/server/docs/dev-server.md
+++ b/website/server/docs/dev-server.md
@@ -8,15 +8,19 @@ reactivate
 
 That's the whole interface. Under the hood you get Django running as ASGI
 under uvicorn, Vite serving your frontend with hot module replacement, a
-TypeScript compiler in watch mode, and client asset generation — spawned
+TypeScript compiler in watch mode, and client asset generation. Spawned
 together, wired together, and torn down together when you hit Ctrl-C.
+
+Nothing here needs Nix. `reactivate` is a console script installed with the
+Python package; it wants `DEBUG_PORT` set and your node modules installed,
+and that's it.
 
 ## Two modes
 
 **Vite mode** is the default. Vite owns the user-facing port and proxies
 everything that isn't an asset to Django. You get HMR, instant saves, the
 usual modern niceties. Startup blocks until Vite is actually listening rather
-than guessing with a sleep, and fails loudly if Vite dies on boot — no
+than guessing with a sleep, and fails loudly if Vite dies on boot. No
 half-started server that looks alive and serves nothing.
 
 **Build mode** (`reactivate --build`) skips the Vite dev server entirely: a
@@ -29,7 +33,7 @@ tunnels, where a module waterfall is unbearable.
 
 Change server code and the dev server doesn't just restart Django. It
 regenerates the client assets too, so a new pick, procedure, or template shows
-up in TypeScript on the very next save — types can't go stale mid-session. In
+up in TypeScript on the very next save. Types can't go stale mid-session. In
 build mode it rebuilds the client bundle as well.
 
 The file watches are scoped to `server/` (plus `client/` in build mode) on
@@ -43,24 +47,25 @@ against.
 Everything is environment-driven; there are no flags to memorize beyond
 `--build`.
 
-- **`DEBUG_PORT`** (required): the user-facing port. The project's shell
-  environment derives and exports it. If it's missing, startup is an explicit
-  error telling you so.
-- **`REACTIVATED_PROCESSES`**: newline-separated sidecar commands — a
-  database tunnel, a worker, whatever your project needs running alongside.
-  They spawn with the server and get cleaned up with it. `$VAR` references
-  resolve at spawn time, including the runtime ports the server just
-  allocated. A sidecar that exits immediately warns instead of killing the
-  server, since the usual cause is another checkout already holding the
-  shared resource.
+- **`DEBUG_PORT`** (required): the user-facing port. Projects created with the
+  [setup script](/documentation/getting-started/) already derive and export
+  this in their shell environment, so there's nothing to do. On an existing
+  project, export it yourself; any free port works. If it's missing, startup
+  is an explicit error telling you so.
+- **`REACTIVATED_PROCESSES`**: newline-separated sidecar commands. A database
+  tunnel, a worker, whatever your project needs running alongside. They spawn
+  with the server and get cleaned up with it. `$VAR` references resolve at
+  spawn time, including the runtime ports the server just allocated. A
+  sidecar that exits immediately warns instead of killing the server, since
+  the usual cause is another checkout already holding the shared resource.
 - **`DEV_URL` / `DEV_EXTRA_URLS`**: what the startup banner prints when your
   project fronts the server through richer hostnames or an HTTPS proxy.
   Without them, plain localhost.
 
 ## Port safety
 
-If something is already serving on `DEBUG_PORT` — usually another checkout's
-dev server — startup is an explicit error naming the port. This matters more
+If something is already serving on `DEBUG_PORT`, usually another checkout's
+dev server, startup is an explicit error naming the port. This matters more
 than it sounds: in Vite mode the loser of a port race binds a wildcard socket
 that macOS happily lets coexist with the winner's, so it "starts" cleanly and
 never receives a single request. We'd rather tell you.

--- a/website/server/docs/existing-projects.md
+++ b/website/server/docs/existing-projects.md
@@ -8,10 +8,10 @@ other packages.
 
 ## Requirements
 
-- Python 3.11
-- Node.js 18
-- PostgreSQL 10 or higher
-- Django 4.3
+- Python 3.12
+- Django 5.1
+- A current Node.js LTS
+- PostgreSQL
 
 Make sure the `python` and `node` executables are available in your `PATH`. Reactivated
 will invoke them as needed.
@@ -37,7 +37,7 @@ the same time.
 
 ## Server Setup
 
-In your Django settings, add `reactivated` to the _end_ of `INSTALLED_APPS`.
+In your Django settings, add `reactivated` to `INSTALLED_APPS`.
 
 At the very top of your `settings.py` file, also add:
 
@@ -58,39 +58,10 @@ STATICFILES_DIRS = (BASE_DIR / "static/",)
 > to rename that folder. Vite's build process relies on the `dist` folder so Reactivated
 > intercepts all requests for static content from that folder.
 
-Now add the `JSX` template backend to your `TEMPLATES` setting. Assuming you want to
-keep your regular Django templates as well, it would look something like this:
-
-```python
-TEMPLATES = [
-    {
-        "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "context_processors": [
-                "django.template.context_processors.debug",
-                "django.template.context_processors.request",
-                "django.contrib.auth.context_processors.auth",
-                "django.contrib.messages.context_processors.messages",
-            ],
-        },
-    },
-    {
-        "BACKEND": "reactivated.backend.JSX",
-        "DIRS": [],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "context_processors": [
-                "django.contrib.messages.context_processors.messages",
-                "django.template.context_processors.csrf",
-                "django.template.context_processors.request",
-                "django.template.context_processors.static",
-            ]
-        },
-    },
-]
-```
+There is no custom template backend to add. Reactivated reads your stock
+`DjangoTemplates` configuration: the context processors listed there become the typed
+`Context` available to your React components. Your existing `TEMPLATES` setting works
+as-is.
 
 ## Client Setup
 
@@ -102,7 +73,6 @@ Next to `manage.py` in `BASE_DIR`, create the following structure:
     -   package.json
     -   tsconfig.json
     -   client
-        -   index.tsx
         -   templates
 ```
 
@@ -110,53 +80,35 @@ Add the following code to `tsconfig.json`:
 
 ```json
 {
-    "compilerOptions": {
-        "strict": true,
-        "sourceMap": true,
-        "noEmit": true,
-        "module": "esnext",
-        "moduleResolution": "node",
-        "target": "es2017",
-        "esModuleInterop": true,
-        "allowJs": true,
-        "jsx": "react",
-        "baseUrl": ".",
-        "skipLibCheck": true,
-        "paths": {
-            "@client/*": ["client/*"],
-            "@reactivated": ["node_modules/_reactivated"],
-            "@reactivated/*": ["node_modules/_reactivated/*"]
-        }
-    },
+    "extends": "reactivated/tsconfig.base.json",
     "include": ["./client/**/*"]
 }
 ```
 
-And the following code to `client/index.tsx`:
+The base config sets strict mode, JSX, and the `@client` / `@reactivated` path
+aliases. Generated code lands in `client/generated/`; add it to your `.gitignore`.
 
-```typescript
-import React from "react";
-import ReactDOM from "react-dom/client";
-import {createRoot} from "react-dom/client";
+Notice there's no `client/index.tsx` in that structure. You don't need one: the
+framework injects a default entry that boots everything. Create the file only when
+you want to customize startup with `reactivate()`. See
+[the entry point](/documentation/templates/#the-entry-point).
 
-import {Provider, getTemplate, getServerData} from "@reactivated";
+## Running it
 
-const {props, context} = getServerData();
-const Template = await getTemplate(context);
+Export a port and start the dev server:
 
-ReactDOM.hydrateRoot(
-    document.getElementById("root") as HTMLElement,
-    <React.StrictMode>
-        <Provider value={context}>
-            <Template {...props} />
-        </Provider>
-    </React.StrictMode>,
-);
+```bash
+export DEBUG_PORT=8000
+reactivate
 ```
 
-That completes the setup. You can now run `python manage.py runserver` to start coding.
+`python manage.py runserver` works too. [The Dev Server](/documentation/dev-server/)
+covers what `reactivate` adds.
 
 ## Next steps
 
-- Review the [API](/documentation/api/) and create your first `template`.
+- Read the [concepts](/documentation/concepts/) and create your first
+  [template](/documentation/templates/).
 - Create a `client/components/Layout.tsx` component that your templates can reference.
+- Then meet [picks](/documentation/picks/) and [RPC](/documentation/rpc/), which is
+  where the framework earns its keep.

--- a/website/server/docs/existing-projects.md
+++ b/website/server/docs/existing-projects.md
@@ -95,15 +95,14 @@ you want to customize startup with `reactivate()`. See
 
 ## Running it
 
-Export a port and start the dev server:
+Start the dev server:
 
 ```bash
-export DEBUG_PORT=8000
 reactivate
 ```
 
-`python manage.py runserver` works too. [The Dev Server](/documentation/dev-server/)
-covers what `reactivate` adds.
+It serves on port 8000; pass `--port` for anything else. `python manage.py runserver`
+works too. [The Dev Server](/documentation/dev-server/) covers what `reactivate` adds.
 
 ## Next steps
 

--- a/website/server/docs/getting-started.md
+++ b/website/server/docs/getting-started.md
@@ -29,9 +29,14 @@ its thing.
 Just run `cd <project_name>`, then `nix-shell` and finally `reactivate`
 
 With the server running, visit the URL printed in the startup banner to see
-Reactivated in action. The classic `python manage.py runserver` works too — see
+Reactivated in action. The classic `python manage.py runserver` works too; see
 [The Dev Server](/documentation/dev-server/) for what `reactivate` adds and why
 it's the recommended entry point.
+
+One thing you won't find in the scaffold: a `client/index.tsx`. You don't need
+one. The framework injects a default entry that boots everything, and you only
+create the file when you want to customize startup. See
+[the entry point](/documentation/templates/#the-entry-point).
 
 ### Next Steps
 

--- a/website/server/docs/getting-started.md
+++ b/website/server/docs/getting-started.md
@@ -26,10 +26,12 @@ its thing.
 
 ### Post Installation
 
-Just run `cd <project_name>`, then `nix-shell` and finally `python manage.py runserver`
+Just run `cd <project_name>`, then `nix-shell` and finally `reactivate`
 
-With the server running, you can visit `http://localhost:8000` to see Reactivated in
-action.
+With the server running, visit the URL printed in the startup banner to see
+Reactivated in action. The classic `python manage.py runserver` works too — see
+[The Dev Server](/documentation/dev-server/) for what `reactivate` adds and why
+it's the recommended entry point.
 
 ### Next Steps
 

--- a/website/server/docs/philosophy-goals.md
+++ b/website/server/docs/philosophy-goals.md
@@ -92,10 +92,10 @@ What does the home page need? First think of the types of resources. But then ga
 them all together in one endpoint.
 
 ```python
-class HomePage(NamedTuple):
-    orders: List[Order]
+class HomePage(Template):
+    orders: list[Order]
     profile: User
-    widgets: List[Widget]
+    widgets: list[Widget]
 ```
 
 Now fulfill this interface:

--- a/website/server/docs/picks.md
+++ b/website/server/docs/picks.md
@@ -1,0 +1,277 @@
+# Picks
+
+Every full-stack app hits the same wall: the server knows your data, the client
+doesn't. Somewhere in between, you end up writing serializers by hand and
+praying the frontend types match.
+
+Picks are Reactivated's answer. You declare exactly which fields of a model
+cross the wire. Reactivated generates the matching TypeScript, validates the
+data at runtime, and refuses to send anything you didn't declare.
+
+Picks live in `reactivated.pick` and are backed by Pydantic. Shapes are real
+classes: they validate, they serialize, and they exist on both sides of the
+wire.
+
+## Declaring a pick
+
+Use `pick()` with a Django model and a list of fields:
+
+```python
+from reactivated.pick import pick
+
+from . import models
+
+BookSummary = pick(models.Book, fields=["id", "title", "author.name"])
+```
+
+Dot paths traverse relations. `author.name` follows the foreign key and picks
+just the `name` off the related model.
+
+For richer nested shapes, pass a tuple of the field name and another pick:
+
+```python
+AuthorDetail = pick(models.Author, fields=["id", "name", "bio"])
+
+BookDetail = pick(
+    models.Book,
+    fields=["id", "title", ("author", AuthorDetail)],
+)
+```
+
+## Input and output
+
+A pick has two sides.
+
+The _output_ side is what the server sends to the client: every declared field,
+serialized from a model instance. The _input_ side is what the client is
+allowed to send back. You get at them with `.output` and `.input`:
+
+```python
+validated = BookSummary.input.model_validate(payload)
+```
+
+Most of the time you won't touch these directly. RPC handlers and templates
+use them for you. But the split matters when a field should only exist on one
+side:
+
+```python
+BookForm = pick(
+    models.Book,
+    fields=["id", "title", "isbn", "internal_notes"],
+    read_only_fields=["id"],
+    write_only_fields=["internal_notes"],
+)
+```
+
+`read_only_fields` exist only on the output. The client can see the `id` but
+cannot submit one. `write_only_fields` are the reverse: the client can send
+`internal_notes`, but the server never echoes them back.
+
+## Returning model instances
+
+Serializers usually force a dance: fetch the model, copy fields into a DTO,
+return the DTO. With picks, you skip it. Annotate your return type with
+`.returns` and hand back the Django instance directly:
+
+```python
+def featured_book() -> BookSummary.returns:
+    return models.Book.objects.filter(featured=True).latest("created_at")
+```
+
+Reactivated serializes exactly the declared fields and nothing else. No
+accidental leaks of columns you forgot the model had.
+
+## Extra fields
+
+Sometimes the shape needs a value that isn't a model field. A computed score,
+a count from another query, whatever. Declare it with `extra_fields` and attach
+it at return time with `.proxy()`:
+
+```python
+BookWithScore = pick(
+    models.Book,
+    fields=["id", "title"],
+    extra_fields={"score": int},
+)
+
+def top_book() -> BookWithScore.returns:
+    book = models.Book.objects.first()
+    return BookWithScore.proxy(book, score=compute_score(book))
+```
+
+The proxy wraps the instance. Model fields resolve as usual, extras come from
+what you passed in, and the TypeScript type includes both.
+
+## Optional fields and stale clients
+
+Here's a bug you only meet in production. You add a field to an input shape
+and deploy. Every client still running the old bundle, and every mobile app
+that hasn't updated, now omits that field on every request. Strict validation
+rejects them all with a 400.
+
+`optional_fields` is the escape hatch built for exactly this:
+
+```python
+SaveBook = pick(
+    models.Book,
+    fields=["id", "title", "subtitle"],
+    optional_fields=["subtitle"],
+)
+```
+
+On the input side, `subtitle` may be omitted entirely; an absent key
+deserializes to `None`. On the TypeScript side it becomes `subtitle?: string |
+null`. The output side is unaffected, since server data always has every
+attribute.
+
+> **Note**: `optional_fields` is restricted to nullable scalar model fields
+> without a model default. After validation, an absent key and an explicit
+> `null` are indistinguishable, and a model default would be shadowed by the
+> implicit `None`.
+
+## Hand-written picks
+
+Not every shape maps to a model. Subclass `Pick` directly for a plain Pydantic
+model that still participates in schema generation:
+
+```python
+from reactivated.pick import Pick
+
+
+class SearchResult(Pick):
+    id: int
+    title: str
+    rank: float
+```
+
+Because `Pick` is configured with `from_attributes`, you can still validate one
+from any object with matching attributes, model or otherwise.
+
+## Inline picks
+
+For a one-off shape you will never reuse, skip the module-level assignment and
+declare the pick inline in the annotation:
+
+```python
+from reactivated.pick import InlinePick
+
+def rename(request: HttpRequest, form: InlinePick[models.Book, Literal["id", "title"]]) -> None:
+    ...
+```
+
+## Enums and export()
+
+Python enums pass through without ceremony. Annotate a field with the enum
+class and it becomes a string union in TypeScript:
+
+```python
+class Format(enum.Enum):
+    HARDCOVER = "Hardcover"
+    PAPERBACK = "Paperback"
+```
+
+On the client, that field is typed `"HARDCOVER" | "PAPERBACK"`. Look closely:
+those are the member _names_, not the values. Enums serialize and type by
+name, and the rule is global. Any enum defined in one of your installed apps
+speaks member names on every wire — pick fields, direct RPC returns, template
+props. No registration step, nothing to remember. Names are identifiers;
+values are display labels, and display labels don't belong in your protocol.
+
+When accepting an enum as input, Pydantic validates the name automatically. No
+mapping tables on either side.
+
+> **Note**: The rule is about enums _you own_. Third-party enums — say, from
+> an SDK's own Pydantic models — keep Pydantic's default value handling, so
+> vendored libraries keep working untouched.
+
+So where do the values come in? When the client needs the labels, `export()`
+emits the runtime value map:
+
+```python
+from reactivated.pick import export
+
+export(Format)
+```
+
+```typescript
+server.store.models.Format.PAPERBACK; // "Paperback"
+```
+
+`export()` is never a serialization prerequisite — it exists to hand the
+client the type and the label map, including for enums nothing else
+references. There is one export path and one addressing scheme: everything
+lands at its server location on the client (more on that below). Module-level
+primitives export too, typed by their annotation. Non-primitives and duplicate
+names are boot errors, not silent surprises.
+
+## Deep picks and the mypy plugin
+
+Time to address the obvious question. `BookSummary = pick(...)` is a function
+call. How does mypy know the result has a `title`, let alone an `author` with a
+`name` on it? Other frameworks stop here: serializer output is a dict, and deep
+attribute access on it is unchecked. You get autocomplete on the model, then
+fall off a cliff at the wire boundary.
+
+The trick is that there is no trick. When Reactivated generates the client
+code, it also generates `pick_schema`, a plain Python module with a genuine
+class for every pick: real annotated fields, real nested classes for
+relations, `input` and `output` both. Open the file and read it. It is
+ordinary code.
+
+The mypy plugin then does exactly one thing. When it sees a `pick()` assignment
+in, say, `store/picks.py`, it looks up the matching generated class,
+`pick_schema.store_picks_BookSummary`, and swaps that symbol in under your
+name. `BookSummary` _is_ the generated class as far as mypy is concerned, so
+`book.author.name` type-checks like any other attribute access, and so does
+every level below it.
+
+That's the entire plugin: a name substitution. No synthesized types, no
+inference logic living inside the checker. Compare that to the heavyweight
+plugins other Django tooling needs, where half the type system is reimplemented
+in plugin hooks.
+
+Enable it in `mypy.ini` alongside django-stubs:
+
+```
+plugins =
+    mypy_django_plugin.main,
+    reactivated.plugin
+```
+
+The lightness is the roadmap. Because everything real lives in generated,
+ordinary Python, any type checker can already read it; what's missing elsewhere
+is only the name swap. Getting that supported in Pyright and ty is where we
+want to go, and a substitution this small is a much easier conversation than "please
+run our type engine."
+
+## The TypeScript side
+
+Everything above lands in generated client code with one import and one
+addressing scheme: the `server` namespace mirrors your Python tree, character
+for character. Imports are _isomorphic_ — the path you'd import on the server
+is the path you use on the client. Same words, same order:
+
+```python
+from server.store.picks import BookSummary
+```
+
+```typescript
+import {server} from "@reactivated";
+
+type Book = server.store.picks.BookSummary.output;
+type BookInput = server.store.picks.BookForm.input;
+```
+
+The same holds for everything the server declares. A procedure in
+`server/store/api.py` is `server.store.api.rename(...)`. A template in
+`server/store/templates.py` is `server.store.templates.BookDetail`. An
+exported enum rides along at its module path too.
+
+No flat registries, no invented names, no guessing what codegen called
+something. If you can write the Python import, you already know the client
+name — and jump-to-definition, grep, and code review all read the same on
+both sides. One way to say everything.
+
+And there's no drift to manage. Rename a field in Python and the TypeScript
+compiler fails on every stale usage. That's the whole point: one declaration,
+checked on both ends.

--- a/website/server/docs/picks.md
+++ b/website/server/docs/picks.md
@@ -173,15 +173,15 @@ class Format(enum.Enum):
 On the client, that field is typed `"HARDCOVER" | "PAPERBACK"`. Look closely:
 those are the member _names_, not the values. Enums serialize and type by
 name, and the rule is global. Any enum defined in one of your installed apps
-speaks member names on every wire — pick fields, direct RPC returns, template
+speaks member names on every wire: pick fields, direct RPC returns, template
 props. No registration step, nothing to remember. Names are identifiers;
 values are display labels, and display labels don't belong in your protocol.
 
 When accepting an enum as input, Pydantic validates the name automatically. No
 mapping tables on either side.
 
-> **Note**: The rule is about enums _you own_. Third-party enums — say, from
-> an SDK's own Pydantic models — keep Pydantic's default value handling, so
+> **Note**: The rule is about enums _you own_. Third-party enums (say, from
+> an SDK's own Pydantic models) keep Pydantic's default value handling, so
 > vendored libraries keep working untouched.
 
 So where do the values come in? When the client needs the labels, `export()`
@@ -197,7 +197,7 @@ export(Format)
 server.store.models.Format.PAPERBACK; // "Paperback"
 ```
 
-`export()` is never a serialization prerequisite — it exists to hand the
+`export()` is never a serialization prerequisite. It exists to hand the
 client the type and the label map, including for enums nothing else
 references. There is one export path and one addressing scheme: everything
 lands at its server location on the client (more on that below). Module-level
@@ -248,7 +248,7 @@ run our type engine."
 
 Everything above lands in generated client code with one import and one
 addressing scheme: the `server` namespace mirrors your Python tree, character
-for character. Imports are _isomorphic_ — the path you'd import on the server
+for character. Imports are _isomorphic_: the path you'd import on the server
 is the path you use on the client. Same words, same order:
 
 ```python
@@ -267,10 +267,9 @@ The same holds for everything the server declares. A procedure in
 `server/store/templates.py` is `server.store.templates.BookDetail`. An
 exported enum rides along at its module path too.
 
-No flat registries, no invented names, no guessing what codegen called
-something. If you can write the Python import, you already know the client
-name — and jump-to-definition, grep, and code review all read the same on
-both sides. One way to say everything.
+No registry of invented names, no guessing what codegen called something. If
+you can write the Python import, you already know the client name. Jump-to-definition, grep, and code review all read the same on both
+sides. One way to say everything.
 
 And there's no drift to manage. Rename a field in Python and the TypeScript
 compiler fails on every stale usage. That's the whole point: one declaration,

--- a/website/server/docs/rpc.md
+++ b/website/server/docs/rpc.md
@@ -178,6 +178,12 @@ widget, label, and required state. What we don't have yet is documentation and
 first-class helpers for _rendering_ it; projects currently read the schema and
 build their own field components. That guide is coming.
 
+If you'd rather not wait: the `@form` class is exported at its server path as
+a plain `as const` object. `server.store.api.ReviewForm` carries a `fields`
+map with each field's widget, label, placeholder, and required state, plus the
+field order, all typed. `Object.entries()` it and render whatever you like.
+That's exactly what our own projects do today.
+
 ## Outputs
 
 Return anything serializable: primitives, Pydantic models, enums, lists, or a

--- a/website/server/docs/rpc.md
+++ b/website/server/docs/rpc.md
@@ -41,7 +41,7 @@ urlpatterns = [
 ```
 
 That's the entire backend. On the client, a typed function now exists at the
-path mirroring the Python module — `server/store/api.py` becomes
+path mirroring the Python module. `server/store/api.py` becomes
 `server.store.api`:
 
 ```typescript
@@ -56,57 +56,70 @@ if (result.type === "success") {
 
 No fetch calls, no URL strings, no hand-written response types.
 
-## Scopes are the access control
+## Authentication
 
 A bare `@router.rpc` is public: the request itself is the handler's first
-argument. Everything else hangs off a _scope_ — the same gates that protect
-your views. A scope proves something once and returns a typed _product_;
-procedures registered on the scope receive that product as their first
-argument, the _principal_:
+argument. For everything else, the common case ships with the router:
 
 ```python
-from typing import Literal
+from reactivated.pick import Pick
+
+from . import models
 
 
-@router.scope
-def merchant(request: HttpRequest) -> models.Merchant | Literal[False]:
-    if not request.user.is_authenticated or not request.user.is_merchant:
-        return False
-    return models.Merchant.from_user(request.user)
+class ReviewForm(Pick):
+    book_id: int
+    rating: int
+    comment: str = ""
 
 
-class RenameForm(Pick):
-    name: str
-
-
-@merchant.rpc
-def rename_shop(who: models.Merchant, form: RenameForm) -> None:
-    who.shop.name = form.name
-    who.shop.save()
-```
-
-Look at the handler's signature. It doesn't take a request. It takes a
-`models.Merchant`, and mypy holds you to it. There's no `request.user`
-unwrapping, no `assert user.is_merchant` copy-pasted into every function, no
-decorator whose guarantees live only in your memory. If the scope returns
-`False`, the framework responds with a 401 and your handler never runs.
-
-The same scope gates pages, with a transport-appropriate denial: views
-redirect to login, procedures return `{"error": "UNAUTHORIZED"}` with a 401.
-One gate, both transports.
-
-For the everyday case, the router ships with batteries:
-
-```python
 @router.authenticated.rpc
 def create_review(user: models.User, form: ReviewForm) -> None:
     book = models.Book.objects.get(pk=form.book_id)
     models.Review.objects.create(book=book, user=user, rating=form.rating)
 ```
 
-`router.authenticated` injects your project's concrete `User` (via
-django-stubs) and denies anonymous callers. `router.maybe_authenticated` is
-the soft version: `User | None`, never denies.
+Look at the handler's signature. It doesn't take a request. It takes your
+project's concrete `User` (via django-stubs), and mypy holds you to it.
+There's no `request.user` unwrapping, no `assert user.is_authenticated`
+copy-pasted into every function, no decorator whose guarantees live only in
+your memory. An anonymous caller gets a 401 and your handler never runs.
+
+`router.maybe_authenticated` is the soft version: the handler receives
+`User | None` and nobody is denied.
+
+## Scopes gate procedures
+
+Past plain authentication, access control is a _scope_: the same gates that
+protect your [views](/documentation/views/). A scope proves something once and
+returns a typed product; procedures registered on the scope receive that
+product as their first argument:
+
+```python
+from typing import Literal
+
+
+@router.scope
+def staff(request: HttpRequest) -> HttpRequest | Literal[False]:
+    if not request.user.is_staff:
+        return False
+    return request
+
+
+@staff.rpc
+def purge_cache(request: HttpRequest) -> None:
+    ...
+```
+
+If the scope returns `False`, the framework responds with a 401 and
+`{"error": "UNAUTHORIZED"}`. The same scope gates pages with a
+transport-appropriate denial: views redirect to login, procedures get the 401.
+One gate, both transports.
+
+Scopes can resolve real objects too, so a whole family of procedures shares
+one lookup. The [views documentation](/documentation/views/) covers scope
+trees, products, and refinement in depth; everything there applies to
+procedures as well.
 
 ## Inputs
 
@@ -142,26 +155,52 @@ def archive_book(user: models.User, book_id: int) -> None:
 await server.store.api.archive_book({book_id: 42});
 ```
 
-> **Note**: For richer inputs, `FormField()` from `reactivated.forms` attaches
-> widget, label, and placeholder metadata to a field, so the client can render
-> real form controls from the schema alone.
+Inputs can also drive real form UIs. Decorate a `Pick` with `@form` and
+declare fields with `FormField` to attach widget, label, and placeholder
+metadata. The client renders controls from the schema alone:
+
+```python
+from reactivated.forms import FormField, form
+
+
+@form(exclude=["book_id"])
+class ReviewForm(Pick):
+    book_id: int
+    rating: int = FormField(label="Rating")
+    comment: str | None = FormField(widget="textarea", required=False)
+```
+
+`exclude` marks fields the rendered form never shows; the client supplies
+`book_id` programmatically.
 
 ## Outputs
 
 Return anything serializable: primitives, Pydantic models, enums, lists, or a
-pick's `.returns` so you can hand back Django instances directly:
+pick's `.returns` to hand back Django instances directly:
 
 ```python
 BookSummary = pick(models.Book, fields=["id", "title", "author.name"])
 
 
-@router.query(merchant)
-def search_books(who: models.Merchant, query: str) -> list[BookSummary.returns]:
+@router.query
+def search_books(request: HttpRequest, query: str) -> list[BookSummary.returns]:
     return list(models.Book.objects.filter(title__icontains=query)[:20])
 ```
 
 `router.query()` is the shorthand for read-only endpoints: GET, no
 transaction.
+
+Without `.returns`, the return type would be `BookSummary.output` and every
+handler would end in ceremony:
+
+```python
+return [BookSummary.output.model_validate(book) for book in found]
+```
+
+Worse than ceremony, it's a typing hole. `model_validate` accepts `Any`, so
+mypy will happily bless a call that validates the wrong object, and you find
+out at runtime. With `.returns`, the declared return type _is_ the model
+class. Hand back the wrong model and mypy flags the handler, not your pager.
 
 ## Handling the result
 
@@ -189,7 +228,7 @@ decide what a validation error looks like in your UI, at compile time.
 The decorator takes a few knobs, all with sensible defaults:
 
 ```python
-@merchant.rpc(
+@staff.rpc(
     atomic_requests=True,   # default: one transaction spans scopes, validation, handler
     csrf_exempt=False,      # default
     methods=["POST"],       # default; add "GET" for cacheable reads
@@ -198,11 +237,11 @@ The decorator takes a few knobs, all with sensible defaults:
 ```
 
 Handlers may be sync or async, and both honor `atomic_requests`: under the
-default, writes roll back on error either way — async handlers are bounced
-onto the transaction thread to get there, since Django transactions are
-sync-only. An async handler that needs the event loop (streaming, concurrent
-IO) and no transaction should say so with `atomic_requests=False`; that's the
-natively awaited path.
+default, writes roll back on error either way. Async handlers are bounced onto
+the transaction thread to get there, since Django transactions are sync-only.
+An async handler that needs the event loop (streaming, concurrent IO) and no
+transaction should say so with `atomic_requests=False`; that's the natively
+awaited path.
 
 ## Observing requests
 
@@ -254,11 +293,6 @@ be plain function calls.
 
 ## Status codes, for the curious
 
-| Scenario                  | Status | Client result  |
-| ------------------------- | ------ | -------------- |
-| Handler returns           | 200    | `success`      |
-| Validation fails          | 400    | `invalid`      |
-| The scope returns `False` | 401    | `unauthorized` |
-| Wrong HTTP method         | 405    | —              |
-
-You will rarely think about these. The generated client already did.
+A success is a 200. Validation failures are a 400 and arrive as `invalid`. A
+denied scope is a 401, `unauthorized` on the client. The wrong HTTP method is
+a 405. You'll rarely think about these; the generated client already did.

--- a/website/server/docs/rpc.md
+++ b/website/server/docs/rpc.md
@@ -155,9 +155,9 @@ def archive_book(user: models.User, book_id: int) -> None:
 await server.store.api.archive_book({book_id: 42});
 ```
 
-Inputs can also drive real form UIs. Decorate a `Pick` with `@form` and
+Inputs can also carry form metadata. Decorate a `Pick` with `@form` and
 declare fields with `FormField` to attach widget, label, and placeholder
-metadata. The client renders controls from the schema alone:
+information:
 
 ```python
 from reactivated.forms import FormField, form
@@ -170,8 +170,13 @@ class ReviewForm(Pick):
     comment: str | None = FormField(widget="textarea", required=False)
 ```
 
-`exclude` marks fields the rendered form never shows; the client supplies
+`exclude` marks fields a rendered form should never show; the client supplies
 `book_id` programmatically.
+
+The metadata lands in the generated schema, so the client knows every field's
+widget, label, and required state. What we don't have yet is documentation and
+first-class helpers for _rendering_ it; projects currently read the schema and
+build their own field components. That guide is coming.
 
 ## Outputs
 

--- a/website/server/docs/rpc.md
+++ b/website/server/docs/rpc.md
@@ -190,14 +190,19 @@ The decorator takes a few knobs, all with sensible defaults:
 
 ```python
 @merchant.rpc(
-    atomic_requests=True,   # default: wrap the handler in a transaction
+    atomic_requests=True,   # default: one transaction spans scopes, validation, handler
     csrf_exempt=False,      # default
     methods=["POST"],       # default; add "GET" for cacheable reads
     log=False,              # False | True | "errors"
 )
 ```
 
-Handlers may be sync or async; sync handlers are wrapped for you.
+Handlers may be sync or async, and both honor `atomic_requests`: under the
+default, writes roll back on error either way — async handlers are bounced
+onto the transaction thread to get there, since Django transactions are
+sync-only. An async handler that needs the event loop (streaming, concurrent
+IO) and no transaction should say so with `atomic_requests=False`; that's the
+natively awaited path.
 
 ## Observing requests
 

--- a/website/server/docs/rpc.md
+++ b/website/server/docs/rpc.md
@@ -1,0 +1,259 @@
+# RPC
+
+REST asks you to model your app as resources. But screens don't want
+resources. They want use cases. A profile page needs three fields from three
+tables, and the "right" REST design gives you three round trips or one bloated
+endpoint pretending to be a resource.
+
+We think the old MVC instinct was correct: one endpoint per use case. Think
+`UpdateProfile`, not `UserResource`. Reactivated's RPC framework is that idea
+with types: plain Python functions, validated inputs, and a generated
+TypeScript client, so calling the server feels like calling a function.
+
+## Your first RPC
+
+Procedures register on the same `Router` that serves your
+[views](/documentation/views/). Decorate a function, mount the router:
+
+```python
+from django.http import HttpRequest
+from django.utils import timezone
+
+from reactivated.router import Router
+
+router = Router()
+
+
+@router.rpc
+def server_time(request: HttpRequest) -> str:
+    return timezone.now().isoformat()
+```
+
+```python
+# urls.py
+from reactivated import mount
+
+from . import api
+
+urlpatterns = [
+    *mount(api),
+]
+```
+
+That's the entire backend. On the client, a typed function now exists at the
+path mirroring the Python module — `server/store/api.py` becomes
+`server.store.api`:
+
+```typescript
+import {server} from "@reactivated";
+
+const result = await server.store.api.server_time();
+
+if (result.type === "success") {
+    console.log(result.data); // string, because Python said so
+}
+```
+
+No fetch calls, no URL strings, no hand-written response types.
+
+## Scopes are the access control
+
+A bare `@router.rpc` is public: the request itself is the handler's first
+argument. Everything else hangs off a _scope_ — the same gates that protect
+your views. A scope proves something once and returns a typed _product_;
+procedures registered on the scope receive that product as their first
+argument, the _principal_:
+
+```python
+from typing import Literal
+
+
+@router.scope
+def merchant(request: HttpRequest) -> models.Merchant | Literal[False]:
+    if not request.user.is_authenticated or not request.user.is_merchant:
+        return False
+    return models.Merchant.from_user(request.user)
+
+
+class RenameForm(Pick):
+    name: str
+
+
+@merchant.rpc
+def rename_shop(who: models.Merchant, form: RenameForm) -> None:
+    who.shop.name = form.name
+    who.shop.save()
+```
+
+Look at the handler's signature. It doesn't take a request. It takes a
+`models.Merchant`, and mypy holds you to it. There's no `request.user`
+unwrapping, no `assert user.is_merchant` copy-pasted into every function, no
+decorator whose guarantees live only in your memory. If the scope returns
+`False`, the framework responds with a 401 and your handler never runs.
+
+The same scope gates pages, with a transport-appropriate denial: views
+redirect to login, procedures return `{"error": "UNAUTHORIZED"}` with a 401.
+One gate, both transports.
+
+For the everyday case, the router ships with batteries:
+
+```python
+@router.authenticated.rpc
+def create_review(user: models.User, form: ReviewForm) -> None:
+    book = models.Book.objects.get(pk=form.book_id)
+    models.Review.objects.create(book=book, user=user, rating=form.rating)
+```
+
+`router.authenticated` injects your project's concrete `User` (via
+django-stubs) and denies anonymous callers. `router.maybe_authenticated` is
+the soft version: `User | None`, never denies.
+
+## Inputs
+
+The parameter after the principal is the body. Type it with a `Pick`, a
+[pick's](/documentation/picks/) `.input` side, any Pydantic model, or even a
+list of them:
+
+```python
+BookForm = pick(models.Book, fields=["id", "title", "isbn"], read_only_fields=["id"])
+
+
+@router.authenticated.rpc
+def update_books(user: models.User, forms: list[BookForm.input]) -> None:
+    ...
+```
+
+Invalid input never reaches your code. The framework responds with a 400 and a
+list of `{loc, msg}` errors, which the client receives as a typed `invalid`
+result. Show them next to the offending fields and you have server-validated
+forms with no duplicated validation logic.
+
+Path parameters work too. Positional parameters annotated `int`, `str`, or
+`uuid.UUID` become URL segments, and the generated client asks for them
+first:
+
+```python
+@router.authenticated.rpc
+def archive_book(user: models.User, book_id: int) -> None:
+    ...
+```
+
+```typescript
+await server.store.api.archive_book({book_id: 42});
+```
+
+> **Note**: For richer inputs, `FormField()` from `reactivated.forms` attaches
+> widget, label, and placeholder metadata to a field, so the client can render
+> real form controls from the schema alone.
+
+## Outputs
+
+Return anything serializable: primitives, Pydantic models, enums, lists, or a
+pick's `.returns` so you can hand back Django instances directly:
+
+```python
+BookSummary = pick(models.Book, fields=["id", "title", "author.name"])
+
+
+@router.query(merchant)
+def search_books(who: models.Merchant, query: str) -> list[BookSummary.returns]:
+    return list(models.Book.objects.filter(title__icontains=query)[:20])
+```
+
+`router.query()` is the shorthand for read-only endpoints: GET, no
+transaction.
+
+## Handling the result
+
+Every generated client function returns an `RPCResult<T>`, a discriminated
+union you can exhaustively handle:
+
+```typescript
+const result = await server.store.api.create_review({book_id: 5, rating: 4});
+
+if (result.type === "success") {
+    // result.data is typed as the handler's return type
+} else if (result.type === "invalid") {
+    // result.errors: {loc: string[], msg: string}[]
+} else if (result.type === "unauthorized") {
+    // the scope said no: send them to login
+}
+```
+
+The full union is `success`, `invalid`, `unauthorized`, `denied`, and
+`exception`. Nothing is thrown for expected failures; the type forces you to
+decide what a validation error looks like in your UI, at compile time.
+
+## Options
+
+The decorator takes a few knobs, all with sensible defaults:
+
+```python
+@merchant.rpc(
+    atomic_requests=True,   # default: wrap the handler in a transaction
+    csrf_exempt=False,      # default
+    methods=["POST"],       # default; add "GET" for cacheable reads
+    log=False,              # False | True | "errors"
+)
+```
+
+Handlers may be sync or async; sync handlers are wrapped for you.
+
+## Observing requests
+
+For logging, metrics, or audit trails, register a single observer for the
+whole router:
+
+```python
+from reactivated.rpc import RequestStatus, rpc_observer
+
+
+@rpc_observer
+async def observe(request, rpc_name, log, status, input, output, body, exception):
+    if status is not RequestStatus.SUCCESS:
+        logger.warning("rpc %s failed: %s", rpc_name, status)
+```
+
+The observer runs after every RPC with its name, its status (`SUCCESS`,
+`INVALID`, `MALFORMED`, or `ERROR`), the parsed input and output, and the
+exception if one escaped. One function, every endpoint, no middleware
+archaeology.
+
+## Testing
+
+Here's the payoff of the principal design that nobody advertises: an RPC
+handler is just a callable. The decorator registers it with the router and
+hands it back untouched, with the same `(principal, form)` signature it was
+written with. So in a test, you skip the router, the URL, and HTTP entirely:
+
+```python
+def test_create_review(db: None) -> None:
+    user = models.User.objects.create_user("reader")
+    book = models.Book.objects.create(title="Middlemarch")
+
+    create_review(user, ReviewForm(book_id=book.pk, rating=4))
+
+    assert book.reviews.count() == 1
+```
+
+No test client, no request factory, no mocking `request.user`. The handler
+never wanted a request; it wanted a `User`, and you have one. Public handlers
+accept whatever `RequestFactory` gives you, but for the common authenticated
+case there's nothing to fake at all.
+
+And the test is type-checked like everything else. Pass a misshapen form or
+the wrong principal and mypy fails the test file before pytest ever runs it.
+When you want the full HTTP treatment, validation, status codes and all, the
+endpoint is still there for an integration test. But most of your coverage can
+be plain function calls.
+
+## Status codes, for the curious
+
+| Scenario                  | Status | Client result  |
+| ------------------------- | ------ | -------------- |
+| Handler returns           | 200    | `success`      |
+| Validation fails          | 400    | `invalid`      |
+| The scope returns `False` | 401    | `unauthorized` |
+| Wrong HTTP method         | 405    | —              |
+
+You will rarely think about these. The generated client already did.

--- a/website/server/docs/styles.md
+++ b/website/server/docs/styles.md
@@ -4,7 +4,7 @@ Without any configuration, you can write CSS files and import them from your com
 No magic, no tooling.
 
 The simplest approach would be to import your stylesheet in your layout component.
-Imagine our templates all render inside `BASE_DIR/components/Layout.tsx`:
+Imagine our templates all render inside `BASE_DIR/client/components/Layout.tsx`:
 
 ```typescript
 import React from "react";
@@ -16,7 +16,7 @@ export const Layout = (props: {children: React.ReactNode}) => (
 );
 ```
 
-And inside `BASE_DIR/style.css` write our styles:
+And inside `client/styles.css` write our styles:
 
 ```css
 .layout {
@@ -27,50 +27,56 @@ And inside `BASE_DIR/style.css` write our styles:
 
 No magic, no tooling. Just classic CSS.
 
-## Zero runtime CSS-in-JS
+## Tailwind, built in
 
-Classic CSS is fine, but it's not great. But we firmly believe the best approach is
-CSS-in-JS that statically compiles to a CSS stylesheet.
+Classic CSS is fine, but most projects reach for [Tailwind](https://tailwindcss.com)
+these days, and we get the appeal: utilities colocate with the markup, and colocation
+is [kind of our thing](/documentation/philosophy-goals/#colocation-is-a-good-thing).
 
-[Vanilla Extract](https://vanilla-extract.style) is one of the newer libraries in the
-space. Reactivated comes with built-in support. No extra tooling or configuration
-needed.
+So Reactivated ships it. Tailwind 4 runs inside the dev server and the production
+build automatically. There's no `tailwind.config.js`, no PostCSS setup, no plugin to
+wire. Start your stylesheet with the import and you're done:
 
-**There is no [colocation](https://kentcdodds.com/blog/colocation)** with Vanilla
-Extract. Styles _need_ to be in a separate file. Still written in TypeScript though.
-
-Our simple example would have `@client/components/Banner.css.ts`:
-
-```typescript
-import {style} from "@vanilla-extract/css";
-
-export const banner = style({
-    background: "red",
-    border: "1px solid black",
-});
-
-export const highlighted = style({
-    backgroundColor: "blue",
-});
+```css
+@import "tailwindcss";
 ```
 
-And our `@client/components/Banner.tsx`:
+That's the entire setup. Utilities now work in any component:
 
 ```typescript
-import React from "react";
+export const Card = (props: {children: React.ReactNode}) => (
+    <div className="rounded border p-4 shadow">{props.children}</div>
+);
+```
 
+Tailwind 4 is configured in CSS, not JavaScript. Design tokens go in a `@theme`
+block in the same file:
+
+```css
+@import "tailwindcss";
+
+@theme {
+    --color-brand: #1c1917;
+    --font-sans: "Inter", sans-serif;
+}
+```
+
+And every token mints its utilities: `bg-brand`, `text-brand`, `font-sans`, and so
+on.
+
+For conditional classes, `classNames` from `@reactivated` keeps the markup tidy:
+
+```typescript
 import {classNames} from "@reactivated";
 
-import * as css from "./Banner.css";
-
 export const Banner = (props: {
-    children: React.React.Node;
+    children: React.ReactNode;
     isHighlighted?: boolean;
 }) => (
     <div
         className={classNames(
-            css.banner,
-            props.isHighlighted === true && css.highlighted,
+            "rounded border p-4",
+            props.isHighlighted === true && "bg-brand text-white",
         )}
     >
         {props.children}
@@ -78,16 +84,18 @@ export const Banner = (props: {
 );
 ```
 
-You can see Vanilla Extract encourages type safety and pure TypeScript usage. It has a
-powerful [API](https://vanilla-extract.style/documentation).
-
-## Next steps
-
-Be sure to read our [request for comments](/documentation/rfc/) to provide feedback.
+> **Note**: Import your stylesheet from a component like `Layout`, or from
+> `client/index.tsx` if you [have one](/documentation/templates/#the-entry-point).
+> Either way it flows through Vite, so Tailwind processes it in dev and in the
+> production build alike.
 
 ## Other tools
 
 You can likely use JS-only CSS-in-JS libraries like [emotion](https://emotion.sh/) and
 [styled-components](https://styled-components.com).
 
-So long as you stick their runtime-only, no-tooling offerings.
+So long as you stick to their runtime-only, no-tooling offerings.
+
+## Next steps
+
+Be sure to read our [request for comments](/documentation/rfc/) to provide feedback.

--- a/website/server/docs/templates.md
+++ b/website/server/docs/templates.md
@@ -1,0 +1,169 @@
+# Templates
+
+Templates connect Django views to React components. You declare the props in
+Python, render from your view, and write the markup in TSX. The full flow is
+server-rendered; React hydrates on the client if and when you need
+interactivity.
+
+Templates are [picks](/documentation/picks/): Pydantic models whose fields are
+the props your component receives. Same validation, same generated types, same
+deep field access on both sides.
+
+## Declaring a template
+
+Subclass `Template` and annotate your props. By convention, templates live in
+`templates.py` of the corresponding app:
+
+```python
+from reactivated.pick import pick
+from reactivated.templates import Template
+
+from . import models
+
+BookSummary = pick(models.Book, fields=["id", "title", "author.name"])
+
+
+class BookDetail(Template):
+    book: BookSummary.returns
+    review_count: int
+    can_edit: bool
+```
+
+Note the `.returns` annotation: it means the view can pass the Django model
+instance directly, and serialization picks out the declared fields. No manual
+copying.
+
+Django forms ride along too, via the `DjangoForm` bridge:
+
+```python
+from typing import Annotated
+
+from reactivated.forms import DjangoForm
+
+
+class BookReview(Template):
+    book: BookSummary.returns
+    form: Annotated[forms.ReviewForm, DjangoForm]
+```
+
+## Rendering from a view
+
+The view stays idiomatic Django. Instantiate the template, call `.render()`:
+
+```python
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404
+
+
+def book_detail(request: HttpRequest, book_id: int) -> HttpResponse:
+    book = get_object_or_404(models.Book, pk=book_id)
+
+    return BookDetail(
+        book=book,
+        review_count=book.reviews.count(),
+        can_edit=request.user.is_staff,
+    ).render(request)
+```
+
+Need a different status code? Pass it:
+
+```python
+return NotFound(query=query).render(request, status=404)
+```
+
+There's also `render_to_string(request)` when you want the HTML itself, for
+emails or fragments.
+
+Because templates are Pydantic models, construction _validates_. Pass a wrong
+type and you get an error at render time in Python, with a real traceback,
+instead of `undefined` showing up three components deep in React.
+
+## The React side
+
+Each template expects a component at `client/templates/<ClassName>.tsx` with a
+named `Template` export. Props come from the `server` namespace, at the path
+mirroring the Python module that declared the template. A `BookDetail` in
+`server/store/templates.py` is `server.store.templates.BookDetail`:
+
+```typescript
+import React from "react";
+
+import {server} from "@reactivated";
+
+export const Template = (props: server.store.templates.BookDetail) => (
+    <div>
+        <h1>{props.book.title}</h1>
+        <p>by {props.book.author.name}</p>
+        <p>{props.review_count} reviews</p>
+        {props.can_edit && <a href="edit/">Edit</a>}
+    </div>
+);
+```
+
+Everything is typed. `props.book.author.name` is a `string` because the pick
+said so. Try to read `props.book.isbn` and the compiler stops you, because the
+pick never declared it.
+
+## Components are checked against Python
+
+Here's the part that saves you at refactor time. The generated code contains a
+type-level assertion for every registered template: your component's props
+must accept the shape Python declares. Rename `review_count` on the Python
+side and `tsc` fails, pointing at `BookDetail.tsx`, before you have loaded a
+single page.
+
+This closes the classic gap in server-rendered setups, where the template and
+the view drift apart silently and you find out from a user.
+
+> **Note**: Set the `REACTIVATED_SKIP_TEMPLATE_CHECKS` environment variable to
+> skip these assertions, for instance during a large migration.
+
+## The entry point
+
+One file boots the client: `client/index.tsx` calls `reactivate()`.
+
+```typescript
+import {reactivate} from "@reactivated";
+
+reactivate();
+```
+
+Bare is the default behavior: parse the preloaded server data, resolve the
+template, hydrate the document. Three optional hooks cover everything else:
+
+```typescript
+reactivate({
+    // Browser-only setup, awaited before hydration. Analytics, cordova,
+    // anything window-flavored belongs here as dynamic imports.
+    init: async () => { ... },
+
+    // Wraps the rendered template with your app providers. Runs during SSR
+    // and in the browser — keep it pure so both sides agree on the markup.
+    render: (content, info) => <AppProviders>{content}</AppProviders>,
+
+    // Take over mounting entirely. Skip hydration, mount an SPA root,
+    // whatever your app needs.
+    mount: ({content}) => { ... },
+});
+```
+
+During SSR the entry module is evaluated for its side effect, so its module
+scope must stay node-safe. That's the whole reason `init` exists: it never
+runs on the server.
+
+## Templates inside the Django admin
+
+The admin is too useful to give up and too rigid to restyle. Three `Template`
+subclasses let you embed React into it instead of fighting it:
+
+- `AdminView` renders a fragment embeddable in an admin page.
+- `AdminChangeView` integrates with a model's change form. Call its
+  `change_view(request, model_admin, object_id)` from your `ModelAdmin`.
+- `AdminListView` does the same for the changelist.
+
+On the client side, `reactivateAdmin()` hydrates the SSR'd fragment. It looks
+for the framework's fragment marker and is a no-op when absent, so calling it
+unconditionally from an admin entry is safe.
+
+You keep the admin's authentication, navigation, and URLs, and render the one
+screen that needs to be better than a stacked inline with React.

--- a/website/server/docs/templates.md
+++ b/website/server/docs/templates.md
@@ -11,8 +11,7 @@ deep field access on both sides.
 
 ## Declaring a template
 
-Subclass `Template` and annotate your props. By convention, templates live in
-`templates.py` of the corresponding app:
+Subclass `Template` and annotate your props:
 
 ```python
 from reactivated.pick import pick
@@ -28,6 +27,13 @@ class BookDetail(Template):
     review_count: int
     can_edit: bool
 ```
+
+Declare it wherever the rendering code lives. Some projects keep a
+`templates.py` per app; others define the class right above the view that
+renders it. Both work, and we lean toward
+[colocation](/documentation/philosophy-goals/#colocation-is-a-good-thing): the
+template and its view are the same concern. The one fixed point is the class
+name, because the component file must match it.
 
 Note the `.returns` annotation: it means the view can pass the Django model
 instance directly, and serialization picks out the declared fields. No manual
@@ -120,25 +126,22 @@ the view drift apart silently and you find out from a user.
 
 ## The entry point
 
-One file boots the client: `client/index.tsx` calls `reactivate()`.
+You don't need one. If `client/index.tsx` is missing, the framework injects a
+default entry that boots everything: parse the preloaded server data, resolve
+the template, hydrate the document.
+
+Create the file only when you want the hooks:
 
 ```typescript
 import {reactivate} from "@reactivated";
 
-reactivate();
-```
-
-Bare is the default behavior: parse the preloaded server data, resolve the
-template, hydrate the document. Three optional hooks cover everything else:
-
-```typescript
 reactivate({
     // Browser-only setup, awaited before hydration. Analytics, cordova,
     // anything window-flavored belongs here as dynamic imports.
     init: async () => { ... },
 
     // Wraps the rendered template with your app providers. Runs during SSR
-    // and in the browser — keep it pure so both sides agree on the markup.
+    // and in the browser, so keep it pure: both sides must agree on markup.
     render: (content, info) => <AppProviders>{content}</AppProviders>,
 
     // Take over mounting entirely. Skip hydration, mount an SPA root,

--- a/website/server/docs/views.md
+++ b/website/server/docs/views.md
@@ -1,0 +1,257 @@
+# Views
+
+Two files in every Django app drift apart: `views.py` and `urls.py`. Add a
+view, forget the route. Rename a route, miss a `reverse()`. And a third thing
+drifts worse than either: the permission checks copy-pasted at the top of every
+view, where one missed `assert` is a security bug.
+
+The router fixes all three at once. URLs are derived from your function names
+and signatures, so there's nothing to keep in sync. And access control becomes
+_structural_: you prove who the user is once, in one place, and every view
+downstream receives that proof as a typed argument.
+
+## Scopes
+
+A _scope_ is a gate. It runs before any view underneath it, and it returns one
+of three things:
+
+- A **product**: a typed value proving the gate passed, handed to everything
+  downstream.
+- An **HttpResponse**: an early return, typically a redirect with a message.
+- **`False`**: the canonical denial. The framework redirects to the login page
+  with `next` set.
+
+```python
+from typing import Literal
+
+from django.http import HttpRequest, HttpResponse
+
+from reactivated.router import Router
+
+from . import models
+
+router = Router()
+
+
+@router.scope
+def books(request: HttpRequest) -> models.Member | HttpResponse | Literal[False]:
+    if not request.user.is_authenticated:
+        return False
+    return models.Member.from_user(request.user)
+```
+
+That's the only place in the entire section that checks authentication.
+
+## Views
+
+Views hang directly off the scope. Their first argument is the scope's
+product, already proven:
+
+```python
+@books.index
+def books_list(member: models.Member, request: HttpRequest) -> HttpResponse:
+    return BookList(books=member.books.all()).render(request)
+
+
+@books.view
+def books_export(member: models.Member, request: HttpRequest) -> HttpResponse:
+    ...
+```
+
+Notice what's missing. No `@login_required`, no `request.user` in sight, no
+assert at the top. A view that takes a `models.Member` cannot be reached
+without one existing. That's not discipline, that's the type system.
+
+The URLs came for free:
+
+```
+books/           -> books_list    (index: the scope's own URL)
+books/export/    -> books_export  (the name minus the parent prefix, kebab-cased)
+```
+
+And `reverse()` names are simply the function names: `reverse("books_export")`.
+
+## Parameterized scopes
+
+Scopes nest. A child scope takes the parent's product plus keyword-only URL
+parameters, and hangs off the parent the same way views do:
+
+```python
+@books.scope
+def book(member: models.Member, *, book_id: int) -> models.Book | HttpResponse | Literal[False]:
+    return get_object_or_404(member.books, pk=book_id)
+
+
+@book.index
+def book_detail(item: models.Book, request: HttpRequest) -> HttpResponse:
+    ...
+
+
+@book.view
+def book_reviews(item: models.Book, member: models.Member, request: HttpRequest) -> HttpResponse:
+    ...
+```
+
+The parameter annotation picks the URL converter, so the routes become:
+
+```
+books/<int:book_id>/           -> book_detail
+books/<int:book_id>/reviews/   -> book_reviews
+```
+
+Two things worth noticing. The lookup goes through `member.books`, so "does
+this book belong to this member" is checked exactly once, for every view under
+the scope. And `book_reviews` takes a third argument: a view may also ask for
+the _root_ product when it needs both.
+
+## The built-in gates
+
+Plain login checks are so common they ship with the router. `router.authenticated`
+is a ready-made root scope whose product is your project's concrete `User`
+type, via django-stubs:
+
+```python
+@router.authenticated.scope
+def library(user: models.User, *, library_id: int) -> models.Library | Literal[False]:
+    ...
+```
+
+There's also `router.maybe_authenticated`, the soft version: its product is
+`User | None` and it never denies. Both work for [RPC](/documentation/rpc/)
+as well.
+
+## Refinement scopes
+
+The pattern that pays for the whole system. Some views need more than "logged
+in": billing configured, email verified, whatever your domain calls trusted.
+Model that as a scope with an empty path that mints a `NewType`:
+
+```python
+from typing import NewType
+
+Owner = NewType("Owner", models.Member)
+
+
+@books.scope(path="")
+def owner(member: models.Member, request: HttpRequest) -> Owner | HttpResponse:
+    if member.billing_incomplete:
+        messages.info(request, "Finish setting up billing first.")
+        return redirect("books_list")
+    return Owner(member)
+
+
+@owner.view
+def owner_billing(who: Owner, request: HttpRequest) -> HttpResponse:
+    ...
+```
+
+`path=""` means the scope adds no URL segment; `owner_billing` lives at
+`books/billing/`. But it demands an `Owner`, and the only place an `Owner` is
+ever created is that one gate. Try to hang a billing view off the plain
+`books` scope and mypy rejects it. The trust hierarchy is now a fact about
+your types, not a convention in your code review checklist.
+
+## Wiring it up
+
+`urls.py` shrinks to a `mount()`:
+
+```python
+from reactivated import mount
+
+from . import views
+
+urlpatterns = [
+    *mount(views),
+    # ... anything else
+]
+```
+
+`mount()` takes modules that own a `router` (or router instances directly) and
+emits their URL patterns with _global_ duplicate detection: routes and reverse
+names must be unique across everything mounted, pages and procedures alike. A
+conflict is a boot error naming the culprits, instead of Django silently
+first-matching one of them.
+
+There's also `router.routes()`, which returns the `(route, name)` table. Drop
+it into a snapshot test and your URL surface is under version control:
+
+```python
+def test_routes() -> None:
+    assert router.routes() == [
+        ("books/", "books_list"),
+        ("books/export/", "books_export"),
+        ("books/<int:book_id>/", "book_detail"),
+        ("books/<int:book_id>/reviews/", "book_reviews"),
+        ("books/billing/", "owner_billing"),
+    ]
+```
+
+## Testing
+
+The decorated name is the original function. Not a wrapper, not a callable
+object: your function, with the signature you wrote. So testing view logic is
+calling a function with a product you constructed:
+
+```python
+def test_book_detail(rf: RequestFactory, db: None) -> None:
+    response = book_detail(book, rf.get("/"))
+
+    assert response.status_code == 200
+```
+
+When you want the gates too — the full chain a URL would run —
+`router.endpoint()` hands you the Django-callable for any registered view:
+
+```python
+def test_book_detail_requires_login(rf: RequestFactory) -> None:
+    request = rf.get("/books/1/")
+    request.user = AnonymousUser()
+
+    response = router.endpoint(book_detail)(request, book_id=1)
+
+    assert response.status_code == 302  # login redirect, with next set
+```
+
+No test client, no URL resolution, no middleware stack. Compare this to the
+usual routine: a logged-in session, `reverse()`, and a full request cycle, all
+to exercise thirty lines of view code. Here a view is a function, its gates
+are functions, and tests call functions.
+
+## Everything fails at boot
+
+The router refuses to start, not to serve, when something is wrong. At import
+time it checks:
+
+- URL parameters must be annotated `int`, `str`, or `uuid.UUID`.
+- View names must start with their parent's name: `book_reviews` under `book`,
+  never `reviews`.
+- Duplicate routes and duplicate reverse names are rejected — per router at
+  registration, and across all routers at `mount()`.
+- `path=` overrides may pin static words only. Parameters come from
+  signatures, nowhere else.
+- Scope and view arities are enforced, so a gate cannot silently take the
+  wrong arguments.
+
+A misnamed view is a `TypeError` on boot, not a 404 in production.
+
+## The override hatch
+
+Function names drive URLs, and one override exists: `path=` with static words,
+for when the URL should not match the name.
+
+```python
+@books.view(path="reading-list")
+def books_saved(member: models.Member, request: HttpRequest) -> HttpResponse:
+    ...
+```
+
+One knob. If you find yourself wanting more, the framework is nudging you to
+rename the function instead. It's usually right.
+
+## Scopes gate procedures too
+
+The same scope tree serves [RPC](/documentation/rpc/). `@book.rpc` declares a
+procedure whose principal is the scope's product, gated by the identical
+chain — with a transport-appropriate denial: pages redirect to login,
+procedures return a 401. Prove who the user is once; every page _and_ every
+procedure underneath inherits the proof.

--- a/website/server/docs/views.md
+++ b/website/server/docs/views.md
@@ -2,28 +2,24 @@
 
 Two files in every Django app drift apart: `views.py` and `urls.py`. Add a
 view, forget the route. Rename a route, miss a `reverse()`. And a third thing
-drifts worse than either: the permission checks copy-pasted at the top of every
-view, where one missed `assert` is a security bug.
+drifts worse than either: the lookup and permission checks copy-pasted at the
+top of every view.
 
-The router fixes all three at once. URLs are derived from your function names
-and signatures, so there's nothing to keep in sync. And access control becomes
-_structural_: you prove who the user is once, in one place, and every view
-downstream receives that proof as a typed argument.
+The router fixes all three. URLs derive from your function names and
+signatures, so there's nothing to keep in sync. And the copy-pasted preamble
+becomes a _scope_: resolve something once, and every view underneath receives
+it as a typed argument.
 
 ## Scopes
 
-A _scope_ is a gate. It runs before any view underneath it, and it returns one
-of three things:
+A scope is shared resolution. It runs before any view underneath it, and
+whatever it returns, the _product_, is handed down to every view and child
+scope below.
 
-- A **product**: a typed value proving the gate passed, handed to everything
-  downstream.
-- An **HttpResponse**: an early return, typically a redirect with a message.
-- **`False`**: the canonical denial. The framework redirects to the login page
-  with `next` set.
+No authentication yet. Watch what a scope does for a plain public site:
 
 ```python
-from typing import Literal
-
+from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 
 from reactivated.router import Router
@@ -34,52 +30,44 @@ router = Router()
 
 
 @router.scope
-def books(request: HttpRequest) -> models.Member | HttpResponse | Literal[False]:
-    if not request.user.is_authenticated:
-        return False
-    return models.Member.from_user(request.user)
+def books(request: HttpRequest) -> QuerySet[models.Book]:
+    return models.Book.objects.filter(published=True)
 ```
 
-That's the only place in the entire section that checks authentication.
+Every page in this section shows published books only. That rule now lives in
+exactly one place.
 
-## Views
-
-Views hang directly off the scope. Their first argument is the scope's
-product, already proven:
+Views hang directly off the scope, and their first argument is its product:
 
 ```python
 @books.index
-def books_list(member: models.Member, request: HttpRequest) -> HttpResponse:
-    return BookList(books=member.books.all()).render(request)
+def books_list(published: QuerySet[models.Book], request: HttpRequest) -> HttpResponse:
+    return BookList(books=list(published)).render(request)
 
 
 @books.view
-def books_export(member: models.Member, request: HttpRequest) -> HttpResponse:
+def books_search(published: QuerySet[models.Book], request: HttpRequest) -> HttpResponse:
     ...
 ```
-
-Notice what's missing. No `@login_required`, no `request.user` in sight, no
-assert at the top. A view that takes a `models.Member` cannot be reached
-without one existing. That's not discipline, that's the type system.
 
 The URLs came for free:
 
 ```
-books/           -> books_list    (index: the scope's own URL)
-books/export/    -> books_export  (the name minus the parent prefix, kebab-cased)
+books/          -> books_list    (index: the scope's own URL)
+books/search/   -> books_search  (the name minus the parent prefix, kebab-cased)
 ```
 
-And `reverse()` names are simply the function names: `reverse("books_export")`.
+And `reverse()` names are simply the function names: `reverse("books_search")`.
 
 ## Parameterized scopes
 
 Scopes nest. A child scope takes the parent's product plus keyword-only URL
-parameters, and hangs off the parent the same way views do:
+parameters:
 
 ```python
 @books.scope
-def book(member: models.Member, *, book_id: int) -> models.Book | HttpResponse | Literal[False]:
-    return get_object_or_404(member.books, pk=book_id)
+def book(published: QuerySet[models.Book], *, book_id: int) -> models.Book | HttpResponse:
+    return get_object_or_404(published, pk=book_id)
 
 
 @book.index
@@ -88,7 +76,7 @@ def book_detail(item: models.Book, request: HttpRequest) -> HttpResponse:
 
 
 @book.view
-def book_reviews(item: models.Book, member: models.Member, request: HttpRequest) -> HttpResponse:
+def book_reviews(item: models.Book, request: HttpRequest) -> HttpResponse:
     ...
 ```
 
@@ -99,57 +87,87 @@ books/<int:book_id>/           -> book_detail
 books/<int:book_id>/reviews/   -> book_reviews
 ```
 
-Two things worth noticing. The lookup goes through `member.books`, so "does
-this book belong to this member" is checked exactly once, for every view under
-the scope. And `book_reviews` takes a third argument: a view may also ask for
-the _root_ product when it needs both.
+Notice the lookup goes through the parent's queryset. An unpublished book 404s
+on every page under the scope, from one `get_object_or_404`. Still no auth in
+sight: scopes earn their keep on structure and shared lookups alone.
 
-## The built-in gates
+When a view needs both products, declare a third parameter. The root scope's
+product arrives as the second positional argument.
 
-Plain login checks are so common they ship with the router. `router.authenticated`
-is a ready-made root scope whose product is your project's concrete `User`
-type, via django-stubs:
+## Gates
+
+Now the part everyone expects. A scope has three options, and only one of them
+is a product:
+
+- A **product**: proceed, hand it down.
+- An **HttpResponse**: an early return, typically a redirect with a message.
+- **`False`**: the canonical denial. The framework redirects to the login page
+  with `next` set.
+
+The everyday gate ships with the router. `router.authenticated` is a built-in
+scope whose product is your project's concrete `User`, via django-stubs:
 
 ```python
 @router.authenticated.scope
-def library(user: models.User, *, library_id: int) -> models.Library | Literal[False]:
+def shelf(user: models.User) -> QuerySet[models.SavedBook]:
+    return user.saved_books.all()
+
+
+@shelf.index
+def shelf_list(saved: QuerySet[models.SavedBook], request: HttpRequest) -> HttpResponse:
     ...
 ```
 
-There's also `router.maybe_authenticated`, the soft version: its product is
-`User | None` and it never denies. Both work for [RPC](/documentation/rpc/)
-as well.
+An anonymous visitor never reaches `shelf_list`; they bounce to login. And the
+view receives the user's own saved books, already filtered. There's no
+`@login_required` because there's nothing to forget.
+
+`router.maybe_authenticated` is the soft version: its product is `User | None`
+and it never denies.
+
+A custom gate is just a scope that can say no:
+
+```python
+from typing import Literal
+
+
+@router.scope
+def staff(request: HttpRequest) -> HttpRequest | Literal[False]:
+    if not request.user.is_staff:
+        return False
+    return request
+```
 
 ## Refinement scopes
 
-The pattern that pays for the whole system. Some views need more than "logged
+One more trick, for when trust has grades. Some views need more than "logged
 in": billing configured, email verified, whatever your domain calls trusted.
 Model that as a scope with an empty path that mints a `NewType`:
 
 ```python
 from typing import NewType
 
-Owner = NewType("Owner", models.Member)
+Subscriber = NewType("Subscriber", models.User)
 
 
-@books.scope(path="")
-def owner(member: models.Member, request: HttpRequest) -> Owner | HttpResponse:
-    if member.billing_incomplete:
-        messages.info(request, "Finish setting up billing first.")
+@router.authenticated.scope(path="")
+def subscriber(user: models.User, request: HttpRequest) -> Subscriber | HttpResponse:
+    if not user.has_active_subscription:
+        messages.info(request, "Subscribe to unlock this.")
         return redirect("books_list")
-    return Owner(member)
+    return Subscriber(user)
 
 
-@owner.view
-def owner_billing(who: Owner, request: HttpRequest) -> HttpResponse:
+@subscriber.view
+def subscriber_billing(who: Subscriber, request: HttpRequest) -> HttpResponse:
     ...
 ```
 
-`path=""` means the scope adds no URL segment; `owner_billing` lives at
-`books/billing/`. But it demands an `Owner`, and the only place an `Owner` is
-ever created is that one gate. Try to hang a billing view off the plain
-`books` scope and mypy rejects it. The trust hierarchy is now a fact about
-your types, not a convention in your code review checklist.
+`path=""` means the scope adds no URL segment; the view lives at `billing/`.
+But it demands a `Subscriber`, and the only place one is ever minted is that
+gate. Hang a billing view off a plain scope and mypy rejects it. The trust
+hierarchy is now a fact about your types, not a convention in your code review
+checklist.
 
 ## Wiring it up
 
@@ -179,10 +197,10 @@ it into a snapshot test and your URL surface is under version control:
 def test_routes() -> None:
     assert router.routes() == [
         ("books/", "books_list"),
-        ("books/export/", "books_export"),
+        ("books/search/", "books_search"),
         ("books/<int:book_id>/", "book_detail"),
         ("books/<int:book_id>/reviews/", "book_reviews"),
-        ("books/billing/", "owner_billing"),
+        ("billing/", "subscriber_billing"),
     ]
 ```
 
@@ -199,15 +217,15 @@ def test_book_detail(rf: RequestFactory, db: None) -> None:
     assert response.status_code == 200
 ```
 
-When you want the gates too — the full chain a URL would run —
+When you want the gates too, the full chain a URL would run,
 `router.endpoint()` hands you the Django-callable for any registered view:
 
 ```python
-def test_book_detail_requires_login(rf: RequestFactory) -> None:
-    request = rf.get("/books/1/")
+def test_shelf_requires_login(rf: RequestFactory) -> None:
+    request = rf.get("/shelf/")
     request.user = AnonymousUser()
 
-    response = router.endpoint(book_detail)(request, book_id=1)
+    response = router.endpoint(shelf_list)(request)
 
     assert response.status_code == 302  # login redirect, with next set
 ```
@@ -225,8 +243,8 @@ time it checks:
 - URL parameters must be annotated `int`, `str`, or `uuid.UUID`.
 - View names must start with their parent's name: `book_reviews` under `book`,
   never `reviews`.
-- Duplicate routes and duplicate reverse names are rejected — per router at
-  registration, and across all routers at `mount()`.
+- Duplicate routes and duplicate reverse names are rejected, per router at
+  registration and across all routers at `mount()`.
 - `path=` overrides may pin static words only. Parameters come from
   signatures, nowhere else.
 - Scope and view arities are enforced, so a gate cannot silently take the
@@ -241,7 +259,7 @@ for when the URL should not match the name.
 
 ```python
 @books.view(path="reading-list")
-def books_saved(member: models.Member, request: HttpRequest) -> HttpResponse:
+def books_saved(published: QuerySet[models.Book], request: HttpRequest) -> HttpResponse:
     ...
 ```
 
@@ -252,6 +270,6 @@ rename the function instead. It's usually right.
 
 The same scope tree serves [RPC](/documentation/rpc/). `@book.rpc` declares a
 procedure whose principal is the scope's product, gated by the identical
-chain — with a transport-appropriate denial: pages redirect to login,
-procedures return a 401. Prove who the user is once; every page _and_ every
-procedure underneath inherits the proof.
+chain, with a transport-appropriate denial: pages redirect to login,
+procedures return a 401. Resolve once; every page and every procedure
+underneath inherits it.

--- a/website/server/documentation/views.py
+++ b/website/server/documentation/views.py
@@ -73,15 +73,16 @@ mkShell {
 
 toc = [
     templates.TocEntry(href="getting-started", title="Getting Started"),
+    templates.TocEntry(href="dev-server", title="The Dev Server"),
     templates.TocEntry(href="concepts", title="Concepts"),
     templates.TocEntry(href="philosophy-goals", title="Philosophy & Goals"),
     # Maybe call concepts basics?
     # TocEntry(href="basics", title="Basics"),
-    templates.TocEntry(href="api", title="API"),
     templates.TocEntry(href="picks", title="Picks"),
     templates.TocEntry(href="templates", title="Templates"),
     templates.TocEntry(href="views", title="Views"),
     templates.TocEntry(href="rpc", title="RPC"),
+    templates.TocEntry(href="api", title="API"),
     templates.TocEntry(href="existing-projects", title="Existing Projects"),
     templates.TocEntry(href="deploying", title="Deploying a Reactivated Project"),
     templates.TocEntry(href="styles", title="Styles and CSS"),

--- a/website/server/documentation/views.py
+++ b/website/server/documentation/views.py
@@ -78,6 +78,10 @@ toc = [
     # Maybe call concepts basics?
     # TocEntry(href="basics", title="Basics"),
     templates.TocEntry(href="api", title="API"),
+    templates.TocEntry(href="picks", title="Picks"),
+    templates.TocEntry(href="templates", title="Templates"),
+    templates.TocEntry(href="views", title="Views"),
+    templates.TocEntry(href="rpc", title="RPC"),
     templates.TocEntry(href="existing-projects", title="Existing Projects"),
     templates.TocEntry(href="deploying", title="Deploying a Reactivated Project"),
     templates.TocEntry(href="styles", title="Styles and CSS"),


### PR DESCRIPTION
## Summary

Documentation for the current system, written against `main` as of #472 — every API claim verified in source.

**Four new pages**, registered in the site toc (concepts first, legacy reference last):

- **Picks** — `pick()` and dot-path relations, the input/output split, `.returns`, `extra_fields` + `.proxy()`, `optional_fields` and the stale-client problem it solves, enum-by-name serialization (global, ownership-based; `export()` is never a serialization prerequisite), isomorphic `server.*` addressing, and the mypy plugin: the `pick_schema` name-swap mechanism and the Pyright/ty roadmap.
- **Templates** — class-based `Template`, the `DjangoForm` bridge, props via `server.<app>.templates.<Name>`, the tsc-time component assertion, the `reactivate()` entry hooks (`init`/`render`/`mount`), and the admin trio + `reactivateAdmin()`.
- **Views** — scopes as gates with typed products, `@scope.view`/`@scope.index`/`@scope.scope`, built-in `authenticated`/`maybe_authenticated`, `NewType` refinement scopes, `mount()` with global duplicate detection, boot checks, and testing via direct calls or `router.endpoint()`.
- **RPC** — bare `@router.rpc`, scope-gated procedures (product = principal, transport-appropriate denial), inputs/outputs, `RPCResult`, options (including the sync/async `atomic_requests` semantics: both honor the request transaction; `atomic_requests=False` is the natively awaited path), the observer, and handlers-as-plain-callables testing.

**Plus a dev server page**: `reactivate` in vite and build modes, smart reload with scoped watches, `DEBUG_PORT` / `REACTIVATED_PROCESSES` / `DEV_URL` configuration, port safety, and an honest `runserver` comparison (still works, still patched; the page explains what `reactivate` adds).

**Legacy swept from existing pages**: concepts and api now teach `Template` classes, `pick()`, and the `server` namespace; getting-started points at `reactivate` and the banner URL; the home page drops the `@template` `NamedTuple` snippet, fixes the stale client imports, and gains an RPC showcase section.

## Verification

- All decorator options, status codes (200/400/401/405), the `RPCResult` union, the observer signature, boot checks, and URL converters checked against source and tests.
- Enum-by-name and transaction/savepoint descriptions match `rpc/patches.py` and `rpc/core.py` exactly.
- Dev server page written from `reactivated_dev/cli.py`, not from memory.
- Docs prettier-formatted; example domain is invented (books/store) throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)