### PR TITLE
Fix dev server startup and add a port flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,23 @@ jobs:
                   sleep 20
                   curl -f http://localhost:8000/ | grep -q "The install worked successfully"
                   kill %1 || true
+            - name: Test dev server renders home page
+              run: |
+                  cd integration
+                  nix-shell --command "
+                    reactivate &
+                    pid=\$!
+                    ok=1
+                    for i in \$(seq 60); do
+                      if curl -sf http://localhost:\$DEBUG_PORT/ | grep -q 'The install worked successfully'; then
+                        ok=0
+                        break
+                      fi
+                      sleep 2
+                    done
+                    kill \$pid 2>/dev/null || true
+                    exit \$ok
+                  "
             - name: Run tests after removing example
               run: |
                   cd integration

--- a/packages/reactivated/scripts/build_subtree.sh
+++ b/packages/reactivated/scripts/build_subtree.sh
@@ -18,10 +18,12 @@ fi
 # Compile the TypeScript package to dist/.
 "$ROOT/node_modules/.bin/tsc" --project "$SUBTREE/packages/reactivated/tsconfig.json"
 
-# tsc emits the compiled bin entries without exec bits, and the re-link below
-# does not reliably restore them: a checkout whose install history ever
-# short-circuited bin fixup (e.g. --ignore-scripts) is left with dead bins —
-# "start_vite: Permission denied". Stamp them deterministically.
+# tsc emits the compiled bin entries without exec bits. The re-link below
+# only chmods bin targets for links it CREATES: on a first build the .bin
+# links don't exist yet (npm skips bins whose targets are absent), so fresh
+# checkouts come out executable — but once the links exist, a regenerated
+# dist/ stays non-executable and every bin dies with "Permission denied".
+# Stamp deterministically instead of depending on that state.
 chmod +x "$SUBTREE"/packages/reactivated/dist/*.mjs
 
 # Re-link the file: dependency: its bin entries point into dist/, which only

--- a/packages/reactivated/scripts/build_subtree.sh
+++ b/packages/reactivated/scripts/build_subtree.sh
@@ -18,6 +18,12 @@ fi
 # Compile the TypeScript package to dist/.
 "$ROOT/node_modules/.bin/tsc" --project "$SUBTREE/packages/reactivated/tsconfig.json"
 
+# tsc emits the compiled bin entries without exec bits, and the re-link below
+# does not reliably restore them: a checkout whose install history ever
+# short-circuited bin fixup (e.g. --ignore-scripts) is left with dead bins —
+# "start_vite: Permission denied". Stamp them deterministically.
+chmod +x "$SUBTREE"/packages/reactivated/dist/*.mjs
+
 # Re-link the file: dependency: its bin entries point into dist/, which only
 # now exists.
 npm install ./upstream/reactivated/packages/reactivated

--- a/packages/reactivated/scripts/setup_environment.sh
+++ b/packages/reactivated/scripts/setup_environment.sh
@@ -53,3 +53,14 @@ if [ "$NEED_DATABASE" == true ]; then
 fi
 
 export DATABASE_URL="postgres:///database?host=$TMP_ENV&port=1"
+
+# The dev server (`reactivate`) and per-checkout companions (tunnels,
+# proxies) key their ports off DEBUG_PORT (+1, +2, ... for siblings). Derive
+# a stable per-checkout value from the checkout path; export DEBUG_PORT
+# before entering the shell to override. Echoed so a rare hash collision
+# between two checkouts is visible.
+if [ -z "${DEBUG_PORT:-}" ]; then
+    DEBUG_PORT=$((20000 + ($(readlink -f "$PWD" | cksum | cut -d ' ' -f 1) % 1000) * 10))
+    export DEBUG_PORT
+fi
+echo "Dev port: $DEBUG_PORT (http://localhost:$DEBUG_PORT/)"

--- a/reactivated_dev/cli.py
+++ b/reactivated_dev/cli.py
@@ -28,6 +28,10 @@ build_mode = False
 banner_label = ""
 banner_port = 0
 
+# Used only when neither --port nor DEBUG_PORT names one: the conventional
+# Django dev port, for projects that manage their own environment.
+DEFAULT_PORT = 8000
+
 # (name, proc, process_group). Core processes (vite/tsc) run in their own
 # session and are group-killed; extras stay in our group so they die with the
 # terminal and get a plain SIGTERM.
@@ -164,6 +168,7 @@ def main() -> None:
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--build", action="store_true")
+    parser.add_argument("--port", type=int, default=None)
     args = parser.parse_args()
 
     # A console script doesn't put cwd on sys.path the way `python file.py`
@@ -173,15 +178,14 @@ def main() -> None:
 
     # The user-facing port. In vite mode Vite listens here and proxies to
     # Django; in build mode Django serves the built assets here directly.
-    # Shell-owned static allocation: setup_environment.sh derives and exports
-    # a stable per-checkout value; export DEBUG_PORT yourself to override.
-    if "DEBUG_PORT" not in os.environ:
-        sys.exit(
-            "reactivate: DEBUG_PORT is not set — source "
-            "setup_environment.sh (which derives and exports it), or export "
-            "DEBUG_PORT yourself."
-        )
-    user_port = int(os.environ["DEBUG_PORT"])
+    # --port beats DEBUG_PORT (the project shell's stable per-checkout
+    # allocation — setup_environment.sh exports it, keeping parallel worktrees
+    # and their port-block companions collision-free) beats the conventional
+    # default.
+    user_port = args.port or int(os.environ.get("DEBUG_PORT") or DEFAULT_PORT)
+    # Extra processes resolve $DEBUG_PORT-derived values at spawn time, and
+    # children read the env — keep everything on the EFFECTIVE port.
+    os.environ["DEBUG_PORT"] = str(user_port)
 
     # A live server here means another instance (usually another worktree) owns
     # the port. Vite mode cannot detect this on its own: the express server

--- a/reactivated_dev/cli.py
+++ b/reactivated_dev/cli.py
@@ -173,11 +173,13 @@ def main() -> None:
 
     # The user-facing port. In vite mode Vite listens here and proxies to
     # Django; in build mode Django serves the built assets here directly.
-    # Shell-owned static allocation: the project env derives and exports it.
+    # Shell-owned static allocation: setup_environment.sh derives and exports
+    # a stable per-checkout value; export DEBUG_PORT yourself to override.
     if "DEBUG_PORT" not in os.environ:
         sys.exit(
-            "reactivate: DEBUG_PORT is not set — the project shell environment "
-            "derives and exports it (see helpers.sh)."
+            "reactivate: DEBUG_PORT is not set — source "
+            "setup_environment.sh (which derives and exports it), or export "
+            "DEBUG_PORT yourself."
         )
     user_port = int(os.environ["DEBUG_PORT"])
 


### PR DESCRIPTION
Startup fixes and standard port handling for the dev server, for fresh checkouts and conventionally-managed environments alike:

- **Port resolution is now `--port` → `DEBUG_PORT` → 8000** (the standard layering every comparable dev server uses). `setup_environment.sh` derives and exports a stable per-checkout `DEBUG_PORT` (path-hash, echoed on entry, existing value respected) — projects using it keep collision-free parallel worktrees and their port-block companions (+1, +2 offsets). Projects that manage their own environment get a server that just starts on the conventional default. The hard "DEBUG_PORT is not set" exit is gone; the effective port is re-exported so extra processes and children stay consistent under an override.
- **Dead compiled bins fixed deterministically.** tsc emits `dist/*.mjs` without exec bits, and npm's re-link only chmods bin targets for links it *creates* — fresh checkouts come out fine (links don't exist yet), but once links exist, a regenerated `dist/` stays non-executable: `start_vite: Permission denied`. `build_subtree.sh` now stamps them after compiling, independent of npm's link state.
- **The dev server is now exercised in integration CI**: the scaffolded project boots `reactivate` (vite mode) and polls the rendered home page on the environment-derived port — this step fails without the `setup_environment.sh` change and passes with it.