### PR TITLE
Remove Kodiak for native auto-merge

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,5 +1,0 @@
-version = 1
-merge.method = "squash"
-merge.delete_branch_on_merge = true
-merge.message.title = "pull_request_title"
-merge.message.body = "empty"

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -19,7 +19,7 @@ jobs:
                   path-to-signatures: "signatures/version1/cla.json"
                   path-to-document: "https://www.reactivated.io/contributor-license-agreement/"
                   branch: "main"
-                  allowlist: dependabot[bot],kodiakhq[bot]
+                  allowlist: dependabot[bot],sga-automerge[bot]
                   custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA. If applicable, I have secured permission from my employer."
                   remote-organization-name: getreactivated
                   remote-repository-name: contributor-license-agreement


### PR DESCRIPTION
Companion to servers#4 (the automerge train): removes `.kodiak.toml` and swaps `kodiakhq[bot]` for `sga-automerge[bot]` in the CLA allowlist — the app now makes the branch-update commits on armed PRs (fork PRs included, same update-branch API Kodiak used), and the CLA check must not demand it sign.

Merge settings already flipped (squash = PR title/blank body — Kodiak was overriding these; now the repo settings encode the same convention natively).

Commit message candidates:
1. **Remove Kodiak for native auto-merge** (selected)
2. Remove Kodiak
3. Switch automerge to native auto-merge
4. Replace Kodiak with native automerge
5. Remove Kodiak and allowlist the automerge app

🤖 Generated with [Claude Code](https://claude.com/claude-code)