### PR TITLE
Fail installs on peer conflicts

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -32,5 +32,5 @@ runs:
           shell: bash
           run: nix-shell --command ""
         - name: Build
-          run: nix-shell --command "npm install && python scripts/generate_types.py && npm exec -w reactivated tsc && playwright install && npm install"
+          run: nix-shell --command "npm ci && python scripts/generate_types.py && npm exec -w reactivated tsc && playwright install && npm install"
           shell: bash

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+; Peer conflicts fail loudly at the SOURCE: this repo generates the
+; lockfiles every consumer inherits via subtree updates. Sloppy upstream
+; peer ranges get an explicit overrides decision, never a silent guess.
+strict-peer-deps=true

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "postinstall": "patch-package"
     },
     "overrides": {
-        "react": "^19.0.0"
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
     }
 }


### PR DESCRIPTION
Strictness lives at the source: this repo generates the lockfiles every consumer inherits via subtree updates, so peer conflicts here should fail loudly instead of npm "reasonably guessing" a resolution (its documented default — the mechanism behind silent duplicate-React trees downstream).

- `.npmrc` with `strict-peer-deps=true` — every install, every context, not just CI.
- `react-dom` joins `react` in the root overrides pin.
- CI setup's first install becomes `npm ci` — verify the committed lock, never re-resolve it (the regenerating second install in the type-gen cycle is untouched).

Lock verified clean under strict mode (no changes needed — the current tree already resolves honestly). Sibling PRs land the npm-ci + overrides half in all four consumer repos (MCR's closes its issue #215); this repo is deliberately the only one carrying full strictness — estate-wide strict is the configuration pnpm shipped as a default and reverted for friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)